### PR TITLE
Feature/faster rootids

### DIFF
--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -172,18 +172,35 @@ flywire_rootid <- function(x, method=c("auto", "cloudvolume", "flywire"),
 #'
 #' @examples
 #' \donttest{
+#' \dontrun{
+#' # example based on defining some sample points from real neurons
 #' # sample dataset from FAFB catmaid
 #' n=elmr::dense_core_neurons[[1]]
 #' set.seed(42)
 #' ss=sample(nvertices(n), size=10)
 #' # first convert FAF14 points to FlyWire coordinate space
 #' nx=xform_brain(elmr::dense_core_neurons[[1]], ref="FlyWire", sample="FAFB14")
+#' pts=xyzmatrix(nx)[ss,]
+#' }
+#'
+#' # for simplicity just define those same sample points directly
+#' pts = matrix(
+#' c(428910.52, 110629.64, 174800, 410201.86, 110419.1, 180400,
+#'   337136, 129926.28, 189280, 349981.85, 136041.53, 199280, 398361.74,
+#'   110731.26, 182640, 382789.26, 118987.04, 189920, 358033.92, 171592.92,
+#'   143960, 360990.48, 140277.42, 201400, 376258.06, 125201.51, 194400,
+#'   331370.31, 128338.58, 181760),
+#' ncol = 3, byrow = TRUE,
+#' dimnames = list(NULL, c("X", "Y", "Z"))
+#' )
+#'
+#'
 #'
 #' # now find the ids for the selected xyz locations
-#' flywire_xyz2id(xyzmatrix(nx)[ss,])
+#' flywire_xyz2id(pts)
 #'
 #' # we can also find the supervoxels - much faster
-#' svids=flywire_xyz2id(xyzmatrix(nx)[ss,], root=FALSE)
+#' svids=flywire_xyz2id(pts, root=FALSE)
 #'
 #' # now look up the root ids - very fast with method="cloudvolume", the default
 #' flywire_rootid(svids)

--- a/man/flywire_rootid.Rd
+++ b/man/flywire_rootid.Rd
@@ -4,16 +4,31 @@
 \alias{flywire_rootid}
 \title{Find the root_id of a FlyWire segment / supervoxel.}
 \usage{
-flywire_rootid(x, ...)
+flywire_rootid(
+  x,
+  method = c("auto", "cloudvolume", "flywire"),
+  cloudvolume.url = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{One or more FlyWire segment ids}
 
-\item{...}{Additional arguments passed to \code{\link{pbsapply}} (when more
-than 1 id) or to \code{\link{flywire_fetch}}}
+\item{method}{Whether to use the flywire API (slow but no python required) OR
+cloudvolume (faster for many input ids, but requires python). "auto" (the
+default) will choose "flywire" for length 1 queries, "cloudvolume"
+otherwise.}
+
+\item{cloudvolume.url}{An optional URL specifying the chunked graph server to
+which CloudVolume will connect. When NULL (the default), the}
+
+\item{...}{Additional arguments passed to \code{\link{pbsapply}} and
+eventually \code{\link{flywire_fetch}} when \code{method="flywire"} OR to
+\code{cv$CloudVolume} when \code{method="cloudvolume"}}
 }
 \value{
-A vector of root ids as character vectors
+A vector of root ids as character vectors named by the input
+  supervoxel ids.
 }
 \description{
 Find the root_id of a FlyWire segment / supervoxel.
@@ -24,9 +39,12 @@ The main purpose of this function is to convert a supervoxel into
   due to editing, calling this the original segment id will still return the
   same segment id (although calling it with a supervoxel would return the new
   segment id).
+
+  There are two \code{method}s. flywire is simpler but will be slower for
+  many supervoxels since each id requires a separate http request.
 }
 \examples{
 \dontrun{
-flywire_rootid("81489548781649724")
+flywire_rootid(c("81489548781649724", "80011805220634701"))
 }
 }

--- a/man/flywire_xyz2id.Rd
+++ b/man/flywire_xyz2id.Rd
@@ -48,18 +48,35 @@ Note that finding the supervoxel for a given XYZ location is order
 }
 \examples{
 \donttest{
+\dontrun{
+# example based on defining some sample points from real neurons
 # sample dataset from FAFB catmaid
 n=elmr::dense_core_neurons[[1]]
 set.seed(42)
 ss=sample(nvertices(n), size=10)
 # first convert FAF14 points to FlyWire coordinate space
 nx=xform_brain(elmr::dense_core_neurons[[1]], ref="FlyWire", sample="FAFB14")
+pts=xyzmatrix(nx)[ss,]
+}
+
+# for simplicity just define those same sample points directly
+pts = matrix(
+c(428910.52, 110629.64, 174800, 410201.86, 110419.1, 180400,
+  337136, 129926.28, 189280, 349981.85, 136041.53, 199280, 398361.74,
+  110731.26, 182640, 382789.26, 118987.04, 189920, 358033.92, 171592.92,
+  143960, 360990.48, 140277.42, 201400, 376258.06, 125201.51, 194400,
+  331370.31, 128338.58, 181760),
+ncol = 3, byrow = TRUE,
+dimnames = list(NULL, c("X", "Y", "Z"))
+)
+
+
 
 # now find the ids for the selected xyz locations
-flywire_xyz2id(xyzmatrix(nx)[ss,])
+flywire_xyz2id(pts)
 
 # we can also find the supervoxels - much faster
-svids=flywire_xyz2id(xyzmatrix(nx)[ss,], root=FALSE)
+svids=flywire_xyz2id(pts, root=FALSE)
 
 # now look up the root ids - very fast with method="cloudvolume", the default
 flywire_rootid(svids)

--- a/man/flywire_xyz2id.Rd
+++ b/man/flywire_xyz2id.Rd
@@ -37,17 +37,31 @@ A character vector of segment ids, \code{NA} when lookup fails.
 \description{
 Title
 }
+\details{
+Note that finding the supervoxel for a given XYZ location is order
+  3x faster than finding the root id for the agglomeration of all of the
+  super voxels in a given object. Perhaps less intuitively, if you want to
+  look up many root ids, it is actually quicker to do
+  \code{flywire_xyz2id(,root=F)} followed by \code{\link{flywire_rootid}}
+  since that function can look up many root ids in a single call to the
+  ChunkedGraph server.
+}
 \examples{
-\dontrun{
+\donttest{
 # sample dataset from FAFB catmaid
 n=elmr::dense_core_neurons[[1]]
 set.seed(42)
-ss=sample(nvertices(n), size=20)
-flywire_xyz2id(xyzmatrix(n)[ss,])
-
-# here we actually convert to FlyWire coordinate space which should give a
-# much better match
+ss=sample(nvertices(n), size=10)
+# first convert FAF14 points to FlyWire coordinate space
 nx=xform_brain(elmr::dense_core_neurons[[1]], ref="FlyWire", sample="FAFB14")
+
+# now find the ids for the selected xyz locations
 flywire_xyz2id(xyzmatrix(nx)[ss,])
+
+# we can also find the supervoxels - much faster
+svids=flywire_xyz2id(xyzmatrix(nx)[ss,], root=FALSE)
+
+# now look up the root ids - very fast with method="cloudvolume", the default
+flywire_rootid(svids)
 }
 }

--- a/tests/testthat/test-flywire.R
+++ b/tests/testthat/test-flywire.R
@@ -78,3 +78,22 @@ test_that("can expand a flywire url to get segments", {
     c("720575940621039145", "720575940626877799"))
 
 })
+
+
+test_that("can get root ids", {
+  token=try(chunkedgraph_token(), silent = TRUE)
+  skip_if_not_installed('reticulate')
+  skip_if(inherits(token, "try-error"),
+          "Skipping live flywire tests")
+  skip_if_not(reticulate::py_module_available("cloudvolume"),
+              "Skipping live flywire tests requiring python cloudvolume module")
+
+  svids=c("81489548781649724", "80011805220634701")
+  expect_named(rootids <- flywire_rootid(svids), svids)
+  expect_length(rootids, 2L)
+  expect_is(rootids, 'character')
+  expect_match(rootids, "^7[0-9]{17}")
+
+  expect_equal(flywire_rootid(svids, method = 'cloudvolume'),
+               flywire_rootid(svids, method = 'flywire'))
+})


### PR DESCRIPTION
* Use cloudvolume for batch supervoxel -> root id lookup (>10x faster)
* fix bug in xyz to supervoxel id lookup