### PR TITLE
Add ids type info to flywire_partners()

### DIFF
--- a/R/autosyn.R
+++ b/R/autosyn.R
@@ -51,6 +51,8 @@ ntpredictions_tbl <- function(local = NULL) {
 #'   autapses (i.e. the same neuron connected to itself) and other false
 #'   positives. See Buhmann et al for details and ideas about cleaning up the
 #'   results.
+#'   
+#'   Also note that the ids returned are of the class `integer64` when the output concerns single synapses/connections (e.g. for `flywire_partners()`); and characters when the output concerns entire neurons (e.g. for `flywire_partner_summary()`). See examples below. 
 #'
 #' @param rootid Character vector specifying one or more flywire rootids. As a
 #'   convenience for \code{flywire_partner_summary} this argument is passed to
@@ -77,6 +79,7 @@ ntpredictions_tbl <- function(local = NULL) {
 #' \donttest{
 #' pp=flywire_partners("720575940621039145")
 #' head(pp)
+#' class(pp$post_id)
 #' }
 flywire_partners <- function(rootid, partners=c("outputs", "inputs", "both"),
                              details=FALSE, roots=TRUE, cloudvolume.url=NULL, method=c("auto", "spine", "sqlite"), Verbose=TRUE, local = NULL,...) {
@@ -248,6 +251,7 @@ spine_svids2synapses <- function(svids, Verbose, partners) {
 #'
 #' @examples
 #' \donttest{
+#' # Note that post_id is of the type character
 #' flywire_partner_summary("720575940621039145", partners='out')
 #' flywire_partner_summary("720575940621039145", partners='in')
 #' flywire_partner_summary("720575940621039145")

--- a/R/autosyn.R
+++ b/R/autosyn.R
@@ -51,8 +51,16 @@ ntpredictions_tbl <- function(local = NULL) {
 #'   autapses (i.e. the same neuron connected to itself) and other false
 #'   positives. See Buhmann et al for details and ideas about cleaning up the
 #'   results.
-#'   
-#'   Also note that the ids returned are of the class `integer64` when the output concerns single synapses/connections (e.g. for `flywire_partners()`); and characters when the output concerns entire neurons (e.g. for `flywire_partner_summary()`). See examples below. 
+#'
+#'   Also note that the ids returned are of the class \code{integer64} for
+#'   \code{flywire_partners} where there is one row for each
+#'   synapses/connection; but for \code{flywire_partner_summary} where rows
+#'   report the number of connections between pairs of neurons, they are of type
+#'   \code{character}. This is because the \code{integer64} type is more compact
+#'   but less robust because it is not a base R type but instead provided by the
+#'   \code{bit64} package. Some R functions such as \code{sapply} strip the
+#'   class from \code{integer64} vectors, treating them as doubles of a
+#'   completely different value.
 #'
 #' @param rootid Character vector specifying one or more flywire rootids. As a
 #'   convenience for \code{flywire_partner_summary} this argument is passed to
@@ -251,7 +259,7 @@ spine_svids2synapses <- function(svids, Verbose, partners) {
 #'
 #' @examples
 #' \donttest{
-#' # Note that post_id is of the type character
+#' # Note that post_id is of type character
 #' flywire_partner_summary("720575940621039145", partners='out')
 #' flywire_partner_summary("720575940621039145", partners='in')
 #' flywire_partner_summary("720575940621039145")

--- a/R/utils.R
+++ b/R/utils.R
@@ -252,7 +252,7 @@ nullToZero <- function(x, fill = 0) {
 #' @param pyinstall Whether to do a \code{"basic"} install (enough for most
 #'   functionality) or a \code{"full"} install, which includes tools for
 #'   skeletonising meshes. \code{"cleanenv"} will show you how to clean up your
-#'   Python enviroment removing all packages. \code{"blast"} will show you how
+#'   Python environment removing all packages. \code{"blast"} will show you how
 #'   to completely remove your dedicated miniconda installation. Choosing
 #'   what="none" skips update/install of Python and recommended packages only
 #'   installing extras defined by \code{pkgs}.

--- a/man/flywire_partners.Rd
+++ b/man/flywire_partners.Rd
@@ -82,13 +82,25 @@ FIXME behaviour when there are no partners is not well-defined.
   autapses (i.e. the same neuron connected to itself) and other false
   positives. See Buhmann et al for details and ideas about cleaning up the
   results.
+
+  Also note that the ids returned are of the class \code{integer64} for
+  \code{flywire_partners} where there is one row for each
+  synapses/connection; but for \code{flywire_partner_summary} where rows
+  report the number of connections between pairs of neurons, they are of type
+  \code{character}. This is because the \code{integer64} type is more compact
+  but less robust because it is not a base R type but instead provided by the
+  \code{bit64} package. Some R functions such as \code{sapply} strip the
+  class from \code{integer64} vectors, treating them as doubles of a
+  completely different value.
 }
 \examples{
 \donttest{
 pp=flywire_partners("720575940621039145")
 head(pp)
+class(pp$post_id)
 }
 \donttest{
+# Note that post_id is of type character
 flywire_partner_summary("720575940621039145", partners='out')
 flywire_partner_summary("720575940621039145", partners='in')
 flywire_partner_summary("720575940621039145")

--- a/man/simple_python.Rd
+++ b/man/simple_python.Rd
@@ -14,7 +14,7 @@ simple_python(
 \item{pyinstall}{Whether to do a \code{"basic"} install (enough for most
 functionality) or a \code{"full"} install, which includes tools for
 skeletonising meshes. \code{"cleanenv"} will show you how to clean up your
-Python enviroment removing all packages. \code{"blast"} will show you how
+Python environment removing all packages. \code{"blast"} will show you how
 to completely remove your dedicated miniconda installation. Choosing
 what="none" skips update/install of Python and recommended packages only
 installing extras defined by \code{pkgs}.}


### PR DESCRIPTION
Add information in Details and Examples about the type of ids returned, as discussed in #107.