### PR TITLE
Chunk flywire_rootid lookups

### DIFF
--- a/R/fafbseg-package.R
+++ b/R/fafbseg-package.R
@@ -30,6 +30,12 @@
 #'   or larger to speed things up. See \code{\link{brainmaps_xyz2id}} for
 #'   details.
 #'
+#'   \item{\code{fafbseg.flywire_roots.chunksize}} this will default to
+#'   processing 100,000 rootids at a time. Set this smaller if the queries time
+#'   out / give "Request Entity Too Large" errors. Larger settings are unlikely
+#'   to have much of a speed impact. See \code{\link{flywire_rootid}} for
+#'   details.
+#'
 #'   }
 #'
 #' @examples

--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -116,9 +116,9 @@ flywire_change_log <- function(x, root_ids=FALSE, filtered=TRUE, tz="UTC",
 #'   (there is a limit to the post message size), id lookups are chunked into a
 #'   maximum of 100,000 lookups in a single call. This can be modified by
 #'   passing in the \code{chunksize} argument or setting the
-#'   \item{\code{fafbseg.flywire_roots.chunksize}} option. Set this smaller if
-#'   the queries time out / give "Request Entity Too Large" errors. Larger
-#'   settings are unlikely to have much of a speed impact.
+#'   \code{fafbseg.flywire_roots.chunksize} option. Set this smaller if the
+#'   queries time out / give "Request Entity Too Large" errors. Larger settings
+#'   are unlikely to have much of a speed impact.
 #'
 #' @param x One or more FlyWire segment ids
 #' @param method Whether to use the flywire API (slow but no python required) OR

--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -108,8 +108,17 @@ flywire_change_log <- function(x, root_ids=FALSE, filtered=TRUE, tz="UTC",
 #'   these can be very rapidly looked up by \code{\link{flywire_xyz2id}} and
 #'   \code{\link{flywire_rootid}}.
 #'
-#'   There are two \code{method}s. flywire is simpler but will be slower for
-#'   many supervoxels since each id requires a separate http request.
+#'   There are two \code{method}s. flywire is simpler but will be much slower
+#'   for many supervoxels since each id requires a separate http request.
+#'
+#'   The cloudvolume method is \emph{much} faster and can process hundreds of
+#'   ids per second. In order to avoid sending too many requests in one go
+#'   (there is a limit to the post message size), id lookups are chunked into a
+#'   maximum of 100,000 lookups in a single call. This can be modified by
+#'   passing in the \code{chunksize} argument or setting the
+#'   \item{\code{fafbseg.flywire_roots.chunksize}} option. Set this smaller if
+#'   the queries time out / give "Request Entity Too Large" errors. Larger
+#'   settings are unlikely to have much of a speed impact.
 #'
 #' @param x One or more FlyWire segment ids
 #' @param method Whether to use the flywire API (slow but no python required) OR
@@ -180,9 +189,7 @@ flywire_rootid <- function(x, method=c("auto", "cloudvolume", "flywire"),
         unlist(res, use.names = FALSE)
       }
     } else {
-      vol <- flywire_cloudvolume(cloudvolume.url, ...)
-      res=reticulate::py_call(vol$get_roots, x)
-      pyids2bit64(res, as_character = !integer64)
+      flywire_roots_cv(x, cloudvolume.url=cloudvolume.url, integer64 = integer64, ...)
     }
     if(!isTRUE(length(ids)==length(x)))
       stop("Failed to retrieve root ids for all input ids!")
@@ -201,6 +208,36 @@ flywire_rootid <- function(x, method=c("auto", "cloudvolume", "flywire"),
     orig
   } else ids
 }
+
+# private function to process roots, but ensuring that we don't exceed a maximum
+# chunk size
+flywire_roots_cv <- function(x, cloudvolume.url,
+                             chunksize=getOption('fafbseg.flywire_roots.chunksize',1e5),
+                              ..., integer64=TRUE) {
+  nx=length(x)
+  nchunks=ceiling(nx/chunksize)
+  checkmate::assert_int(nchunks, lower=1)
+  chunks=rep(seq_len(nchunks), rep(chunksize, nchunks))[seq_len(nx)]
+  chunkstoread=seq_len(nchunks)
+  vol <- flywire_cloudvolume(cloudvolume.url, ...)
+
+  if(interactive())
+    pb <- progress::progress_bar$new(total = nx, show_after=2,
+                                   format = "  flywire_roots [:bar] :percent eta: :eta")
+
+  res=list()
+  for(i in chunkstoread) {
+    pyres=reticulate::py_call(vol$get_roots, x[chunks==i])
+    res[[length(res)+1]]=pyids2bit64(pyres, as_character = !integer64)
+    if(interactive())
+      pb$tick(length(res[[length(res)]]))
+  }
+  vres=unlist(res, use.names = F)
+  if(integer64)
+    class(vres)='integer64'
+  vres
+}
+
 
 #' Find all the supervoxel (leaf) ids that are part of a FlyWire object
 #'

--- a/man/fafbseg-package.Rd
+++ b/man/fafbseg-package.Rd
@@ -42,6 +42,12 @@ Functions that read some of the raw data formats
   or larger to speed things up. See \code{\link{brainmaps_xyz2id}} for
   details.
 
+  \item{\code{fafbseg.flywire_roots.chunksize}} this will default to
+  processing 100,000 rootids at a time. Set this smaller if the queries time
+  out / give "Request Entity Too Large" errors. Larger settings are unlikely
+  to have much of a speed impact. See \code{\link{flywire_rootid}} for
+  details.
+
   }
 }
 

--- a/man/flywire_rootid.Rd
+++ b/man/flywire_rootid.Rd
@@ -49,8 +49,17 @@ The main purpose of this function is to convert a supervoxel into
   these can be very rapidly looked up by \code{\link{flywire_xyz2id}} and
   \code{\link{flywire_rootid}}.
 
-  There are two \code{method}s. flywire is simpler but will be slower for
-  many supervoxels since each id requires a separate http request.
+  There are two \code{method}s. flywire is simpler but will be much slower
+  for many supervoxels since each id requires a separate http request.
+
+  The cloudvolume method is \emph{much} faster and can process hundreds of
+  ids per second. In order to avoid sending too many requests in one go
+  (there is a limit to the post message size), id lookups are chunked into a
+  maximum of 100,000 lookups in a single call. This can be modified by
+  passing in the \code{chunksize} argument or setting the
+  \item{\code{fafbseg.flywire_roots.chunksize}} option. Set this smaller if
+  the queries time out / give "Request Entity Too Large" errors. Larger
+  settings are unlikely to have much of a speed impact.
 }
 \examples{
 \donttest{

--- a/man/flywire_rootid.Rd
+++ b/man/flywire_rootid.Rd
@@ -57,9 +57,9 @@ The main purpose of this function is to convert a supervoxel into
   (there is a limit to the post message size), id lookups are chunked into a
   maximum of 100,000 lookups in a single call. This can be modified by
   passing in the \code{chunksize} argument or setting the
-  \item{\code{fafbseg.flywire_roots.chunksize}} option. Set this smaller if
-  the queries time out / give "Request Entity Too Large" errors. Larger
-  settings are unlikely to have much of a speed impact.
+  \code{fafbseg.flywire_roots.chunksize} option. Set this smaller if the
+  queries time out / give "Request Entity Too Large" errors. Larger settings
+  are unlikely to have much of a speed impact.
 }
 \examples{
 \donttest{


### PR DESCRIPTION
* should avoid "Request Entity Too Large" errors when looking up many ids at once.
* @alexanderbates fyi