### PR TITLE
Fix flytable maximum cells error by adjusting chunksize

### DIFF
--- a/man/flytable-queries.Rd
+++ b/man/flytable-queries.Rd
@@ -14,7 +14,8 @@ flytable_list_rows(
   desc = FALSE,
   start = 0L,
   limit = Inf,
-  python = FALSE
+  python = FALSE,
+  chunksize = NULL
 )
 
 flytable_query(
@@ -46,6 +47,10 @@ queries to 100 rows. We increase the limit to 100000 rows by default.}
 
 \item{python}{Whether to return a Python pandas \code{DataFrame}. The default
 of \code{FALSE} returns an R \code{data.frame}}
+
+\item{chunksize}{Optional The maximum number of rows to request in one web
+request. For advanced use only as the default value of \code{NULL} will
+fetch as many as possible.}
 
 \item{sql}{A SQL query string. See examples and
 \href{https://seatable.github.io/seatable-scripts/python/query/}{seatable

--- a/tests/testthat/test-flytable.R
+++ b/tests/testthat/test-flytable.R
@@ -13,6 +13,9 @@ test_that("query works", {
                   'data.frame')
   expect_equal(nrow(df), 3L)
   expect_s3_class(fruit <- flytable_list_rows('testfruit'), 'data.frame')
+  expect_equal(flytable_list_rows('testfruit', limit=3), fruit[1:3,])
+  expect_equal(flytable_list_rows('testfruit', limit=3, chunksize = 2), fruit[1:3,])
+
   expect_equal(flytable_nrow('testfruit'), nrow(fruit))
   # same representation via flytable_list_rows or flytable_query
   expect_equal(fruit[rownames(df),colnames(df)], df)


### PR DESCRIPTION
* Error in `flytable_list_rows("info")`
```
 #> Error in py_call_impl(x, dots$args, dots$keywords): ConnectionError: [Errno 413] {"error_msg":"the number of cells accessing the table exceeds the limit"}
```
* turns out that there is now a limit in the number of cells that you can return of 1,000,000
* reported by @YijieYin 
* @schlegelp FYI