### PR TITLE
Another attempt to fix seatable cache issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Imports:
     dplyr,
     httr,
     igraph,
+    jose,
     jsonlite,
     magrittr,
     memoise (>= 2.0),


### PR DESCRIPTION
* seems like the toke associated with the base expires
* but the expiry time is not reliably stored in the python object ...