### PR TITLE
Fix: fetch static metadata when no cell type

### DIFF
--- a/R/flytable.R
+++ b/R/flytable.R
@@ -1008,17 +1008,17 @@ flytable_cell_types <- function(pattern=NULL, version=NULL, timestamp=NULL,
   else NULL
   if(!cache)
     memoise::forget(cell_types_memo)
-  if(is.null(pattern)) pattern="_%"
+  if(is.null(pattern) && !use_static) pattern="_%"
 
   # side specification
   side=NULL
-  if(grepl("_[LR]$", pattern)) {
+  if(isTRUE(grepl("_[LR]$", pattern))) {
     mres=stringr::str_match(pattern, '(.+)_([LR])$')
     pattern=mres[,2]
     side=switch(mres[,3], L='left', R="right", stop("side problem in flytable_cell_types!"))
   }
 
-  if(use_static && substr(pattern,1,1)!="/") {
+  if(use_static && isTRUE(substr(pattern,1,1)!="/")) {
     # we're going to use the static cell type information but we have a SQL like
     pattern=gsub("%", '.*?', pattern, fixed = T)
     pattern=gsub("_", '.{1}', pattern, fixed = T)

--- a/tests/testthat/test-flytable.R
+++ b/tests/testthat/test-flytable.R
@@ -86,5 +86,9 @@ test_that("query works", {
                         flywire_ids('LT33', version = 630)),
     lt33)
 
+  expect_equal(
+    withr::with_options(list(fafbseg.use_static_celltypes=T),
+                        flytable_meta('720575940625808642', version = 630)$side),
+    'left')
 })
 


### PR DESCRIPTION
* cf_meta was missing e.g. side information for cells without a cell type when using static cell types
* this was because the default regular expression was only being tested against cell_type, 
  whereas for flytable queries super_class cell_class etc could also match