### PR TITLE
fix downloading v630 annotations

### DIFF
--- a/R/release-data.R
+++ b/R/release-data.R
@@ -55,9 +55,12 @@ git_pull_helper<-function(repo, branch='main'){
   tr <- git2r::tags(repo)
   if(branch %in% names(tr)) {
     git2r::checkout(tr[[branch]])
-  } else git2r::checkout(repo, branch = branch)
-  # necessary to update local checkout to match remote
-  git2r::pull(repo)
+  } else {
+    git2r::checkout(repo, branch = branch)
+    # necessary to update local checkout to match remote when on branch
+    # nb not required for a tag (unless that changes ...)
+    git2r::pull(repo)
+  }
 }
 
 #' Read or return path to FlyWire annotations manuscript supplementary file


### PR DESCRIPTION
* the issues is that you can't pull after checking out a tag (needs to be associated wiht a branch I suppose)
* but checking out should be enough so long as the tag doesn't change