### PR TITLE
Faster flywire_partner_summary queries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     memoise (>= 2.0),
     nabor,
     nat.templatebrains (> 1.0.0),
+    nat.utils (>= 0.6.1),
     pbapply,
     progress,
     rappdirs,

--- a/R/autosyn.R
+++ b/R/autosyn.R
@@ -406,7 +406,7 @@ flywire_partner_summary <- function(rootids, partners=c("outputs", "inputs"),
   }
   chunksize <- if(method=='cave') 20L else 1L
 
-  rootids=flywire_ids(rootids, unique = TRUE, must_work = TRUE)
+  rootids=sort(flywire_ids(rootids, unique = TRUE, must_work = TRUE))
   details <- if(!is.null(surf)) TRUE
   else if(cleft.threshold>0) 'cleft.threshold' else FALSE
   if (length(rootids) > chunksize) {

--- a/R/autosyn.R
+++ b/R/autosyn.R
@@ -434,6 +434,7 @@ flywire_partner_summary <- function(rootids, partners=c("outputs", "inputs"),
       if(!any(badchunks)) chunks=NULL else {
         chunksize=max(round(chunksize/2), 1)
         chunks=nat.utils::make_chunks(unlist(chunks[badchunks]), chunksize = chunksize)
+        message("Refetching ", sum(lengths(chunks)), " rootids after reducing chunksize to:", chunksize)
       }
     }
     df = dplyr::bind_rows(resmain)
@@ -456,6 +457,7 @@ flywire_partner_summary <- function(rootids, partners=c("outputs", "inputs"),
                           timestamp=timestamp, select_columns=selsyncols, ...)
   } else
     flywire_partners(rootids, partners=partners, local = local, details = details, Verbose = Verbose, method = method)
+  if(is.null(partnerdf)) return(NULL)
   # partnerdf=flywire_partners_memo(rootid, partners=partners)
   if(remove_autapses) {
     partnerdf=partnerdf[partnerdf$post_id!=partnerdf$pre_id,,drop=FALSE]

--- a/R/cave.R
+++ b/R/cave.R
@@ -417,7 +417,8 @@ cave_get_delta_roots <- function(timestamp_past, timestamp_future=Sys.time()) {
 #'   argument is a character vector \bold{it is assumed to be in UTC regardless
 #'   of any timezone specification}. Unless the input character vector contains
 #'   the string "UTC" then a warning will be issued.
-#' @param version Integer materialisation version
+#' @param version Integer materialisation version. The special value of
+#'   \code{'latest'} means the most recent materialisation according to CAVE.
 #' @param timestamp A timestamp to normalise into an R or Python timestamp in
 #'   UTC. The special value of \code{'now'} means the current time in UTC.
 #' @param convert Whether to convert from Python to R timestamp (default:
@@ -476,6 +477,8 @@ flywire_timestamp <- function(version=NULL, timestamp=NULL, convert=TRUE,
   }
 
   fac=flywire_cave_client(datastack_name = datastack_name)
+  if(isTRUE(version=="latest") || is.na(version))
+    version=fac$materialize$version
   version=as.integer(version)
   res=tryCatch(
     reticulate::py_call(fac$materialize$get_timestamp, version),

--- a/R/cave.R
+++ b/R/cave.R
@@ -105,6 +105,16 @@ flywire_cave_client <- memoise::memoise(function(datastack_name = getOption("faf
 #'   specify a timepoint using a timestamp) . Furthermore some \code{filter_in,
 #'   filter_out} queries using columns created by the SQL statement may not be
 #'   possible.
+#'
+#' @section CAVE Row Limits: CAVE servers limit the number of rows that can be
+#'   returned for any query, typically 500,000 rows. For many queries you can
+#'   still use increasing values of \code{offset} to page through the results.
+#'   However, there appear to be restrictions to this. In particular for the
+#'   synapse table, rows are returned in \emph{random} order. Therefore, even if
+#'   you set your own row \code{limit} lower than the server's, you still cannot
+#'   fetch all the rows of your query. Other tables (e.g. nuclei) do not have
+#'   this limitation.
+#'
 #' @param table The name of the table (or view, see views section) to query
 #' @param select_columns Either a character vector naming columns or a python
 #'   dict (required if the query involves multiple tables).
@@ -118,6 +128,14 @@ flywire_cave_client <- memoise::memoise(function(datastack_name = getOption("faf
 #'   value lists that restrict the returned rows (keeping only matches or
 #'   filtering out matches). Commonly used to selected rows for specific
 #'   neurons. See examples and CAVE documentation for details.
+#' @param limit whether to limit the number of rows per query (\code{NULL}
+#'   implies no client side limit but there is typically a server side limit of
+#'   500,000 rows).
+#' @param offset a 0-indexed row number, allows you to page through long results
+#'   (but see section \bold{CAVE Row Limits} for some caveats)
+#' @param fetch_all_rows Whether to fetch all rows of a query that exceeds limit
+#'   (default \code{FALSE}). See section \bold{CAVE Row Limits} for some
+#'   caveats.
 #' @param ... Additional arguments to the query method. See examples and
 #'   details.
 #' @inheritParams flywire_cave_client
@@ -173,6 +191,9 @@ flywire_cave_query <- function(table,
                                filter_in_dict=NULL,
                                filter_out_dict=NULL,
                                select_columns=NULL,
+                               offset=0L,
+                               limit=NULL,
+                               fetch_all_rows=FALSE,
                                ...) {
   if(isTRUE(live) && !is.null(version))
     warning("live=TRUE so ignoring materialization version")
@@ -183,7 +204,8 @@ flywire_cave_query <- function(table,
 
   check_package_available('arrow')
   fac=flywire_cave_client(datastack_name=datastack_name)
-
+  offset=checkmate::asInt(offset, lower = 0L)
+  if(!is.null(limit)) limit=checkmate::asInt(limit, lower = 0L)
   is_view=table %in% cave_views(fac)
   if(!is.null(version)) {
     version=as.integer(version)
@@ -207,33 +229,55 @@ flywire_cave_query <- function(table,
         stop("You are querying a view. select_columns must be a python dict as specified by caveclient.")
     }
   }
-  annotdf <- if(is_view) {
-    if(!is.null(timestamp))
-      warning("Sorry! You cannot specify a timestamp when querying a view.\n",
-      "You can specify older timepoints by using unexpired materialisation versions.\n",
-      "See https://flywire-forum.slack.com/archives/C01M4LP2Y2D/p1697956174773839 for info.")
-    reticulate::py_call(fac$materialize$query_view, view_name=table,
-                        materialization_version=version,
-                        filter_in_dict=filter_in_dict,
-                        filter_out_dict=filter_out_dict,
-                        select_columns=select_columns, ...)
-  } else if(live) {
-    # Live query updates ids
-    timestamp=flywire_timestamp(timestamp = 'now', convert = FALSE)
-    reticulate::py_call(fac$materialize$live_query, table=table,
-                        timestamp=timestamp, filter_in_dict=filter_in_dict,
-                        filter_out_dict=filter_out_dict,
-                        select_columns=select_columns, ...)
-  } else {
-    if(!is.null(timestamp)) flywire_timestamp(timestamp = timestamp, convert = F)
-    reticulate::py_call(fac$materialize$query_table, table=table,
-                        materialization_version=version,
-                        timestamp=timestamp, filter_in_dict=filter_in_dict,
-                        filter_out_dict=filter_out_dict,
-                        select_columns=select_columns, ...)
+
+  annotdfs=list()
+  while(offset>=0) {
+    pymsg <- reticulate::py_capture_output({
+      annotdf <- if(is_view) {
+        if(!is.null(timestamp))
+          warning("Sorry! You cannot specify a timestamp when querying a view.\n",
+                  "You can specify older timepoints by using unexpired materialisation versions.\n",
+                  "See https://flywire-forum.slack.com/archives/C01M4LP2Y2D/p1697956174773839 for info.")
+        reticulate::py_call(fac$materialize$query_view, view_name=table,
+                            materialization_version=version,
+                            filter_in_dict=filter_in_dict,
+                            filter_out_dict=filter_out_dict,
+                            select_columns=select_columns,
+                            offset=offset, limit=limit, ...)
+        } else if(live) {
+          # Live query updates ids
+          timestamp=flywire_timestamp(timestamp = 'now', convert = FALSE)
+          reticulate::py_call(fac$materialize$live_query, table=table,
+                              timestamp=timestamp, filter_in_dict=filter_in_dict,
+                              filter_out_dict=filter_out_dict,
+                              select_columns=select_columns,
+                              offset=offset, limit=limit, ...)
+        } else {
+          if(!is.null(timestamp)) flywire_timestamp(timestamp = timestamp, convert = F)
+          reticulate::py_call(fac$materialize$query_table, table=table,
+                              materialization_version=version,
+                              timestamp=timestamp, filter_in_dict=filter_in_dict,
+                              filter_out_dict=filter_out_dict,
+                              select_columns=select_columns,
+                              offset=offset, limit=limit, ...)
+        }
+        annotdf <- pandas2df(annotdf)
+      }
+    )
+    annotdfs[[length(annotdfs)+1]]=annotdf
+    limited_query=isTRUE(grepl("Limited query to", pymsg))
+    if(limited_query && is.null(limit) && !fetch_all_rows)
+      warning(paste(pymsg,"\nUse fetch_all_rows=T or set an explicit limit to avoid warning!"))
+    offset <- if(fetch_all_rows && limited_query)
+      offset+nrow(annotdf)
+    else -1L
+    message("offset:", offset)
   }
-  pandas2df(annotdf)
+  if(length(annotdfs)==1) annotdfs[[1]]
+  else
+    dplyr::bind_rows(annotdfs)
 }
+
 
 cave_views <- memoise::memoise(function(fac=flywire_cave_client()) {
   vv=fac$materialize$get_views()

--- a/R/cave.R
+++ b/R/cave.R
@@ -271,7 +271,7 @@ flywire_cave_query <- function(table,
     offset <- if(fetch_all_rows && limited_query)
       offset+nrow(annotdf)
     else -1L
-    message("offset:", offset)
+    # message("offset:", offset)
   }
   if(length(annotdfs)==1) annotdfs[[1]]
   else
@@ -313,10 +313,15 @@ flywire_partners_cave <- function(rootid, partners=c("outputs", "inputs"),
   }
   dict=list(as.list(as.character(rootid)))
   names(dict)=ifelse(partners=="outputs", "pre_pt_root_id", "post_pt_root_id")
-  res=flywire_cave_query(datastack_name = datastack_name,
+  res=tryCatch(flywire_cave_query(datastack_name = datastack_name,
                          table = synapse_table,
                          filter_in_dict=cavedict_rtopy(dict),
-                         ...)
+                         ...),
+               warning=function(e) {
+                 warning("Synpase query exceeded row limit!")
+                 NULL
+               })
+  if(is.null(res)) return(res)
   # FIXME - integrate into CAVE query
   if(cleft.threshold>0)
     res=res[res$cleft_score>cleft.threshold,,drop=FALSE]

--- a/man/flywire_cave_query.Rd
+++ b/man/flywire_cave_query.Rd
@@ -13,6 +13,9 @@ flywire_cave_query(
   filter_in_dict = NULL,
   filter_out_dict = NULL,
   select_columns = NULL,
+  offset = 0L,
+  limit = NULL,
+  fetch_all_rows = FALSE,
   ...
 )
 }
@@ -38,6 +41,17 @@ neurons. See examples and CAVE documentation for details.}
 
 \item{select_columns}{Either a character vector naming columns or a python
 dict (required if the query involves multiple tables).}
+
+\item{offset}{a 0-indexed row number, allows you to page through long results
+(but see section \bold{CAVE Row Limits} for some caveats)}
+
+\item{limit}{whether to limit the number of rows per query (\code{NULL}
+implies no client side limit but there is typically a server side limit of
+500,000 rows).}
+
+\item{fetch_all_rows}{Whether to fetch all rows of a query that exceeds limit
+(default \code{FALSE}). See section \bold{CAVE Row Limits} for some
+caveats.}
 
 \item{...}{Additional arguments to the query method. See examples and
 details.}
@@ -102,6 +116,17 @@ CAVE (Connectome Annotation Versioning Engine) provides a shared
   specify a timepoint using a timestamp) . Furthermore some \code{filter_in,
   filter_out} queries using columns created by the SQL statement may not be
   possible.
+}
+
+\section{CAVE Row Limits}{
+ CAVE servers limit the number of rows that can be
+  returned for any query, typically 500,000 rows. For many queries you can
+  still use increasing values of \code{offset} to page through the results.
+  However, there appear to be restrictions to this. In particular for the
+  synapse table, rows are returned in \emph{random} order. Therefore, even if
+  you set your own row \code{limit} lower than the server's, you still cannot
+  fetch all the rows of your query. Other tables (e.g. nuclei) do not have
+  this limitation.
 }
 
 \examples{

--- a/man/flywire_ids.Rd
+++ b/man/flywire_ids.Rd
@@ -35,7 +35,8 @@ character vector, but can be more fragile (default \code{FALSE}).}
 
 \item{unique}{Whether to return only unique ids}
 
-\item{version}{Integer materialisation version}
+\item{version}{Integer materialisation version. The special value of
+\code{'latest'} means the most recent materialisation according to CAVE.}
 
 \item{table}{When \code{x} is a query whether to search \code{brain},
 \code{optic} lobe or \code{both} info tables.}

--- a/man/flywire_partners.Rd
+++ b/man/flywire_partners.Rd
@@ -91,7 +91,8 @@ must be located. Can be a \code{\link{mesh3d}} object, or any object which
 \code{\link{boundingbox}} objects. See \code{\link{pointsinside}} for
 details.}
 
-\item{version}{Integer materialisation version}
+\item{version}{Integer materialisation version. The special value of
+\code{'latest'} means the most recent materialisation according to CAVE.}
 
 \item{timestamp}{A timestamp to normalise into an R or Python timestamp in
 UTC. The special value of \code{'now'} means the current time in UTC.}

--- a/man/flywire_partners.Rd
+++ b/man/flywire_partners.Rd
@@ -28,6 +28,7 @@ flywire_partner_summary(
   surf = NULL,
   version = NULL,
   timestamp = NULL,
+  chunksize = NULL,
   method = c("auto", "spine", "sqlite", "cave"),
   Verbose = NA,
   local = NULL,
@@ -80,9 +81,9 @@ autapses (defaults to TRUE)}
 \item{cleft.threshold}{A threshold for the cleft score calculated by Buhmann
 et al 2019 (default 0, we have used 30-100 to increase specificity)}
 
-\item{summarise}{(This was never implemented.) Whether to
-collapse down the results for multiple query neurons into a single entry
-for each partner neuron.}
+\item{summarise}{(This was never implemented.) Whether to collapse down the
+results for multiple query neurons into a single entry for each partner
+neuron.}
 
 \item{surf}{An object defining a 3D ROI inside which the presynaptic position
 must be located. Can be a \code{\link{mesh3d}} object, or any object which
@@ -94,6 +95,11 @@ details.}
 
 \item{timestamp}{A timestamp to normalise into an R or Python timestamp in
 UTC. The special value of \code{'now'} means the current time in UTC.}
+
+\item{chunksize}{(expert use) number of query neurons to send per chunk to
+cave client. Chunking requests speeds up queries (over sending neurons one
+a time) while still avoiding row number limits on queries with many
+neurons.}
 }
 \value{
 A \code{data.frame} with a \code{regtemplate} attribute specifying

--- a/man/flywire_timestamp.Rd
+++ b/man/flywire_timestamp.Rd
@@ -12,7 +12,8 @@ flywire_timestamp(
 )
 }
 \arguments{
-\item{version}{Integer materialisation version}
+\item{version}{Integer materialisation version. The special value of
+\code{'latest'} means the most recent materialisation according to CAVE.}
 
 \item{timestamp}{A timestamp to normalise into an R or Python timestamp in
 UTC. The special value of \code{'now'} means the current time in UTC.}

--- a/tests/testthat/test-autosyn.R
+++ b/tests/testthat/test-autosyn.R
@@ -6,24 +6,25 @@ test_that("flywire_partners / flywire_partner_summary works", {
   skip_if_not(reticulate::py_module_available("cloudvolume"),
               "Skipping live flywire tests requiring python cloudvolume module")
 
-  expect_message(df <- flywire_partner_summary("720575940616243077", Verbose = T),
-                'Fetching supervoxel.*720575940616243077')
+  sid='720575940616243077'
+  sid=flywire_rootid('81207798658143318')
+
+  expect_message(df <- flywire_partner_summary("720575940628367836", Verbose = T, method = 'spine'),
+                'Fetching supervoxel.*')
   expect_is(df, 'data.frame')
   expect_named(df, c("query", "post_id", "weight"))
-  expect_message(df2 <- flywire_partner_summary("720575940616243077", partners = 'input', Verbose = T),
-                 'Fetching supervoxel.*720575940616243077')
 
-  expect_is(ins <- flywire_partners("720575940616243077", partners = 'inputs'), 'data.frame')
-  expect_is(outs <- flywire_partners("720575940616243077", partners = 'outputs'), 'data.frame')
-  expect_equal(nrow(ins), 156L)
-  expect_equal(nrow(outs), 463L)
+  expect_is(ins <- flywire_partners("720575940628367836", partners = 'inputs'), 'data.frame')
+  expect_is(outs <- flywire_partners("720575940628367836", partners = 'outputs'), 'data.frame')
+  expect_equal(nrow(ins), 301L)
+  expect_equal(nrow(outs), 547L)
 
   nosynapses="720575940425537043"
   # nb there is an extra column when there are multiple input queries
   # and we need to subset both to ensure regtemplate attribute is lost
-  expect_equal(flywire_partners(c("720575940616243077", nosynapses))[names(outs)],
+  expect_equal(flywire_partners(c("720575940628367836", nosynapses))[names(outs)],
                outs[names(outs)])
-  both=flywire_partners("720575940616243077", partners = 'both')
+  both=flywire_partners("720575940628367836", partners = 'both')
   expect_true(all(ins$offset %in% both$offset))
   expect_true(all(outs$offset %in% both$offset))
   expect_true(all(both$offset %in% c(outs$offset, ins$offset)))
@@ -75,9 +76,9 @@ test_that("flywire_partners / flywire_partner_summary works", {
   # check for equivalence of sqlite and spine methods if we have sqlite
   skip_if(is.null(synlinks_tbl()), "Skipping tests relying on sqlite databases")
 
-  both.sqlite=flywire_partners("720575940616243077", partners = 'both',
+  both.sqlite=flywire_partners("720575940628367836", partners = 'both',
                                details=T, method='sqlite', reference='FlyWire')
-  both.spine =flywire_partners("720575940616243077", partners = 'both',
+  both.spine =flywire_partners("720575940628367836", partners = 'both',
                                details=T, method = 'spine')
   common_cols=intersect(colnames(both.sqlite), colnames(both.spine))
   expect_equal(both.sqlite[common_cols], both.spine[common_cols], tolerance = 1e-5)


### PR DESCRIPTION
* chunking eg 20 neurons at a time and sending to cave can give 10x speedups
* but need to be careful about CAVE row limits
* awkwardly you can't just increase your offset and get more rows
* in the process implemented offset/limit arguments for generic CAVE queries
* ... and the ability to fetch all rows of a query (but this doesn't work for the synapse table!)