### PR TITLE
cave query: add livelive, fix live query

### DIFF
--- a/R/cave.R
+++ b/R/cave.R
@@ -58,6 +58,11 @@ check_cave <- memoise::memoise(function(min_version=NULL) {
 #' # the default synapse table for the dataset
 #' info$synapse_table
 #' }
+#'
+#' \dontrun{
+#' # get help on python cave client
+#' reticulate::py_help(fac$info$get_datastack_info)
+#' }
 flywire_cave_client <- memoise::memoise(function(datastack_name = getOption("fafbseg.cave.datastack_name", "flywire_fafb_production")) {
   cavec=check_cave()
   client = try(cavec$CAVEclient(datastack_name))
@@ -236,10 +241,15 @@ flywire_cave_client <- memoise::memoise(function(datastack_name = getOption("faf
 #'
 #' \dontrun{
 #' # timetravel query example
-#' # note use of allow_missing_lookups=T in cas
+#' # note use of allow_missing_lookups=T as not infrequently materialisation
+#' # can fail for a neuron
 #' cambridge_celltypes_v2.783 <- flywire_cave_query('cambridge_celltypes_v2', version = 783,
 #'   timetravel=TRUE, allow_missing_lookups=TRUE,
 #'   select_columns = list(cambridge_celltypes_v2=c("id", "tag", "pt_root_id", "pt_supervoxel_id")))
+#'
+#' # querying by regex on a cell type in this table
+#' mbon012<- flywire_cave_query('cambridge_celltypes_v2', version = 783,
+#' timetravel=TRUE, allow_missing_lookups=TRUE, filter_regex_dict = c(tag='MBON0[12]'))
 #' }
 flywire_cave_query <- function(table,
                                datastack_name = getOption("fafbseg.cave.datastack_name", "flywire_fafb_production"),

--- a/R/cave.R
+++ b/R/cave.R
@@ -518,3 +518,22 @@ flywire_timestamp <- function(version=NULL, timestamp=NULL, convert=TRUE,
   })
   if(convert) cgtimestamp2posixct(res) else res
 }
+
+flywire_version <- function(version=NA, must_work=TRUE,
+                            datastack_name = getOption("fafbseg.cave.datastack_name", "flywire_fafb_production")) {
+  if(is.null(version)) return(NULL)
+  if(is.na(version) ||
+     (is.character(version) && !is.na(pmatch(version,'latest')))) {
+    fac=flywire_cave_client(datastack_name = datastack_name)
+    version=fac$materialize$version
+  } else {
+    version=checkmate::asInt(version)
+    if(must_work) {
+      fac=flywire_cave_client(datastack_name = datastack_name)
+      if(!version %in% fac$materialize$get_versions(expired=TRUE))
+        stop("version: ", version, " is not valid version for datastack: ",
+             fac$info$datastack_name)
+    }
+  }
+  version
+}

--- a/R/cave.R
+++ b/R/cave.R
@@ -303,6 +303,7 @@ flywire_cave_query <- function(table,
     # we will first use the latest time and then travel to timestamp2
     timestamp2=flywire_timestamp(version, timestamp = timestamp, datastack_name = datastack_name)
     timestamp=now
+    version=NULL
     live=2L
   }
 
@@ -353,8 +354,8 @@ flywire_cave_query <- function(table,
                             offset=offset, limit=limit, ...)
         } else if(isTRUE(live==2)) {
           # Live query updates ids
-          timestamp <- if(is.null(timestamp)) now
-          else flywire_timestamp(timestamp = timestamp, convert = FALSE)
+          timestamp <- if(is.null(timestamp) && is.null(version)) now
+          else flywire_timestamp(timestamp = timestamp, version=version, convert = FALSE)
           reticulate::py_call(fac$materialize$live_live_query, table=table,
                               timestamp=timestamp, filter_in_dict=filter_in_dict,
                               filter_out_dict=filter_out_dict,

--- a/R/cave.R
+++ b/R/cave.R
@@ -508,9 +508,7 @@ flywire_timestamp <- function(version=NULL, timestamp=NULL, convert=TRUE,
   }
 
   fac=flywire_cave_client(datastack_name = datastack_name)
-  if(isTRUE(version=="latest") || is.na(version))
-    version=fac$materialize$version
-  version=as.integer(version)
+  version=flywire_version(version, datastack_name = datastack_name)
   res=tryCatch(
     reticulate::py_call(fac$materialize$get_timestamp, version),
     error=function(e) {

--- a/R/cave.R
+++ b/R/cave.R
@@ -303,10 +303,11 @@ flywire_cave_query <- function(table,
                               select_columns=select_columns,
                               offset=offset, limit=limit, ...)
         } else {
-          if(!is.null(timestamp)) flywire_timestamp(timestamp = timestamp, convert = F)
+          if(!is.null(timestamp))
+            warning("ignoring timestamp when `live=FALSE`")
           reticulate::py_call(fac$materialize$query_table, table=table,
                               materialization_version=version,
-                              timestamp=timestamp, filter_in_dict=filter_in_dict,
+                              filter_in_dict=filter_in_dict,
                               filter_out_dict=filter_out_dict,
                               select_columns=select_columns,
                               offset=offset, limit=limit, ...)

--- a/R/cave.R
+++ b/R/cave.R
@@ -519,13 +519,25 @@ flywire_timestamp <- function(version=NULL, timestamp=NULL, convert=TRUE,
   if(convert) cgtimestamp2posixct(res) else res
 }
 
-flywire_version <- function(version=NA, must_work=TRUE,
+flywire_version <- function(version=c('latest', 'earliest', 'first', 'available', 'all'),
+                            must_work=TRUE,
                             datastack_name = getOption("fafbseg.cave.datastack_name", "flywire_fafb_production")) {
   if(is.null(version)) return(NULL)
-  if(is.na(version) ||
-     (is.character(version) && !is.na(pmatch(version,'latest')))) {
+  if(length(version)==1 && is.na(version)) version='latest'
+  if(is.character(version)) {
+    version=match.arg(version)
     fac=flywire_cave_client(datastack_name = datastack_name)
-    version=fac$materialize$version
+
+    if(version=='latest')
+      fac$materialize$version
+    else if(version=='earliest')
+      min(fac$materialize$get_versions())
+    else if(version=='first')
+      min(fac$materialize$get_versions(expired=TRUE))
+    else if(version=='all')
+      fac$materialize$get_versions(expired=TRUE)
+    else if(version=='available')
+      fac$materialize$get_versions()
   } else {
     version=checkmate::asInt(version)
     if(must_work) {
@@ -534,6 +546,6 @@ flywire_version <- function(version=NA, must_work=TRUE,
         stop("version: ", version, " is not valid version for datastack: ",
              fac$info$datastack_name)
     }
+    version
   }
-  version
 }

--- a/R/cave.R
+++ b/R/cave.R
@@ -341,6 +341,9 @@ flywire_cave_query <- function(table,
     limited_query=isTRUE(grepl("Limited query to", pymsg))
     if(limited_query && is.null(limit) && !fetch_all_rows)
       warning(paste(pymsg,"\nUse fetch_all_rows=T or set an explicit limit to avoid warning!"))
+    else if(!limited_query && nzchar(pymsg)) {
+      warning(pymsg)
+    }
     offset <- if(fetch_all_rows && limited_query)
       offset+nrow(annotdf)
     else -1L

--- a/R/cave.R
+++ b/R/cave.R
@@ -103,18 +103,27 @@ flywire_cave_client <- memoise::memoise(function(datastack_name = getOption("faf
 #'   \item use the latest CAVE version
 #'
 #'   }
-#' @section Live and Live Live queries: CAVE versions both root ids in the
-#'   segmentation and annotation tables with the same versioning system. This is
-#'   not really ideal as annotation can keep on evolving even though the
-#'   segmentation is static. There are two options to \emph{time travel}
-#'   annotations to a different point in time. Live queries take the contents of
-#'   a table at some version and update the root ids to match a different
-#'   timepoint (usually now). However the set of annotations remains stuck at
-#'   the selected version.
+#' @section Live and Live Live queries: CAVE versions the segmentation and
+#'   annotation tables with shared version numbers. When a dataset is stable,
+#'   using this single version works well. However, we have found that this
+#'   arrangement is not ideal in many situations, as annotations often evolve
+#'   even though the segmentation is static.
 #'
-#'   Live Live mode (CAVE terminology, \code{live=2}) allows a table to contain
-#'   the latest set of annotations and to have ids time travel to a selected
-#'   timepoint.
+#'   CAVE has two options to update annotations to a different point in time:
+#'   \enumerate{
+#'
+#'   \item \bold{Live queries} take the contents of a table at some version and
+#'   updates the root ids to match a later timepoint (usually now). However the
+#'   set of annotations remains stuck at the selected version. The starting
+#'   materialisation version is chosen to be the most recent one preceding the
+#'   requested timepoint.
+#'
+#'   \item \bold{Live live queries} (CAVE terminology, \code{live=2}) can return
+#'   the state of an annotation table at an arbitrary timepoint. This includes
+#'   annotations that have not yet been incorporated into a released
+#'   materialisation version.
+#'
+#'   }
 #'
 #' @section CAVE Views: In addition to regular database tables, CAVE provides
 #'   support for \bold{views}. These are based on a SQL query which typically
@@ -140,7 +149,11 @@ flywire_cave_client <- memoise::memoise(function(datastack_name = getOption("faf
 #' @param select_columns Either a character vector naming columns or a python
 #'   dict (required if the query involves multiple tables).
 #' @param live Whether to use live query mode, which updates any root ids to
-#'   their current value.
+#'   their current value (or to a specified \code{timestamp}). \code{TRUE} or
+#'   \code{1} selected CAVE's \emph{Live} mode, while \code{2} selects
+#'   \code{Live live} mode which gives access even to annotations that are not
+#'   part of a materialisation version. See section \bold{Live and Live Live
+#'   queries} for details.
 #' @param version An optional CAVE materialisation version number. See details
 #'   and examples.
 #' @param timestamp An optional timestamp as a string or POSIXct, interpreted as

--- a/R/cave.R
+++ b/R/cave.R
@@ -258,6 +258,7 @@ flywire_cave_query <- function(table,
     }
   }
 
+  now=flywire_timestamp(timestamp = 'now', convert = FALSE)
   if(!is.null(filter_in_dict) && !inherits(filter_in_dict, 'python.builtin.dict'))
     filter_in_dict=cavedict_rtopy(filter_in_dict)
   if(!is.null(filter_out_dict) && !inherits(filter_out_dict, 'python.builtin.dict'))
@@ -270,7 +271,6 @@ flywire_cave_query <- function(table,
 
   annotdfs=list()
   # store current time just once in case we iterate over multiple offsets
-  now=flywire_timestamp('now', convert = FALSE)
   while(offset>=0) {
     pymsg <- reticulate::py_capture_output({
       annotdf <- if(is_view) {

--- a/R/cave.R
+++ b/R/cave.R
@@ -326,7 +326,7 @@ flywire_cave_query <- function(table,
     pymsg <- reticulate::py_capture_output({
       annotdf <- if(is_view) {
         if(!is.null(timestamp))
-          warning("Sorry! You cannot specify a timestamp when querying a view.\n",
+          stop("Sorry! You cannot specify a timestamp when querying a view.\n",
                   "You can specify older timepoints by using unexpired materialisation versions.\n",
                   "See https://flywire-forum.slack.com/archives/C01M4LP2Y2D/p1697956174773839 for info.")
         reticulate::py_call(fac$materialize$query_view, view_name=table,

--- a/R/cave.R
+++ b/R/cave.R
@@ -228,6 +228,14 @@ flywire_cave_client <- memoise::memoise(function(datastack_name = getOption("faf
 #' psp_last=flywire_cave_query(table = 'proofreading_status_public_v1',
 #'   version=lastv)
 #' }
+#'
+#' \dontrun{
+#' # timetravel query example
+#' # note use of allow_missing_lookups=T in cas
+#' cambridge_celltypes_v2.783 <- flywire_cave_query('cambridge_celltypes_v2', version = 783,
+#'   timetravel=TRUE, allow_missing_lookups=TRUE,
+#'   select_columns = list(cambridge_celltypes_v2=c("id", "tag", "pt_root_id", "pt_supervoxel_id")))
+#' }
 flywire_cave_query <- function(table,
                                datastack_name = getOption("fafbseg.cave.datastack_name", "flywire_fafb_production"),
                                version=NULL,

--- a/R/cave.R
+++ b/R/cave.R
@@ -60,7 +60,12 @@ check_cave <- memoise::memoise(function(min_version=NULL) {
 #' }
 flywire_cave_client <- memoise::memoise(function(datastack_name = getOption("fafbseg.cave.datastack_name", "flywire_fafb_production")) {
   cavec=check_cave()
-  client = cavec$CAVEclient(datastack_name)
+  client = try(cavec$CAVEclient(datastack_name))
+  if(inherits(client, 'try-error')) {
+    ui_todo("\nPlease run dr_fafbseg() to help diagnose.")
+    stop("There seems to be a problem connecting to datastack: ", datastack_name)
+  }
+  client
 }, ~memoise::timeout(12*3600))
 
 #' Query the FlyWire CAVE annotation system

--- a/R/cave.R
+++ b/R/cave.R
@@ -266,6 +266,9 @@ flywire_cave_query <- function(table,
              "See https://flywire-forum.slack.com/archives/C01M4LP2Y2D/p1697956174773839 for info.")
       timestamp=flywire_timestamp(version, datastack_name = datastack_name, convert = F)
       message("Materialisation version no longer available. Falling back to (slower) timestamp!")
+      # we need to use live query to fetch a timestamp when the version has
+      # expired
+      if(isFALSE(live)) live=TRUE
       version=NULL
     }
   }

--- a/R/cave.R
+++ b/R/cave.R
@@ -526,7 +526,7 @@ flywire_version <- function(version=c('latest', 'earliest', 'first', 'available'
     version=match.arg(version)
     fac=flywire_cave_client(datastack_name = datastack_name)
 
-    if(version=='latest')
+    version <- if(version=='latest')
       fac$materialize$version
     else if(version=='earliest')
       min(fac$materialize$get_versions())
@@ -544,6 +544,6 @@ flywire_version <- function(version=c('latest', 'earliest', 'first', 'available'
         stop("version: ", version, " is not valid version for datastack: ",
              fac$info$datastack_name)
     }
-    version
   }
+  as.integer(version)
 }

--- a/R/cave.R
+++ b/R/cave.R
@@ -390,7 +390,9 @@ flywire_cave_query <- function(table,
       stop("Sorry I do not know how to time travel dataframes without `pt_supervoxel_id`, `pt_root_id` columns!",
            if(is.null(select_columns)) '' else
              '\nPlease review your value of `select_columns`!')
-    res$pt_root_id=flywire_updateids(res$pt_root_id, svids = res$pt_supervoxel_id, timestamp = timestamp2, cache = T)
+    res$pt_root_id=flywire_updateids(
+      res$pt_root_id, svids = res$pt_supervoxel_id, timestamp = timestamp2,
+      cache = T, Verbose = F)
   }
   res
 }

--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -315,7 +315,7 @@ flywire_rootid_cached <- function(svids, timestamp=NULL, integer64=FALSE,
     usvid=id64(svids, integer64 = F, unique = T)
     urid=flywire_rootid_cached(usvid, timestamp = timestamp,
                                integer64=integer64, stop_layer=stop_layer, ...)
-    rids[match(usvid, svids)]=urid
+    rids=urid[match(svids, usvid)]
     return(id64(rids, integer64 = integer64))
   }
   d <- svid2rootid_cache(timestamp, stop_layer)

--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -345,7 +345,9 @@ id64 <- function(x, integer64=FALSE, unique = FALSE, na2zero=TRUE) {
 }
 
 svid2rootid_cache <- memoise::memoise(function(timestamp, stop_layer=1L) {
-  timestampus=as.character(bit64::as.integer64(round(as.numeric(timestamp)*1e6,0)))
+  # use timestamp to the nearest microsecond as key
+  timestampus.numeric=as.numeric(as.POSIXct(timestamp, tz = 'UTC'))*1e6
+  timestampus=as.character(bit64::as.integer64(round(timestampus.numeric,0)))
   vcache64(paste('svid2rootid', timestampus, stop_layer, sep = '-'))
 })
 

--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -219,7 +219,7 @@ flywire_rootid <- function(x, method=c("auto", "cave", "cloudvolume", "flywire")
 
   if(any(duplicated(x))) {
     uids=bit64::as.integer64(unique(x))
-    unames=flywire_rootid(uids, method=method, integer64=integer64, cloudvolume.url = cloudvolume.url, timestamp = timestamp, version = version, stop_layer = stop_layer, cache=FALSE, ...)
+    unames=flywire_rootid(uids, method=method, integer64=integer64, cloudvolume.url = cloudvolume.url, timestamp = timestamp, stop_layer = stop_layer, cache=FALSE, ...)
     ids <- unames[match(bit64::as.integer64(x), uids)]
   } else {
     ids <- if(method=="flywire") {

--- a/man/flywire_cave_client.Rd
+++ b/man/flywire_cave_client.Rd
@@ -38,4 +38,9 @@ info=fac$info$get_datastack_info()
 # the default synapse table for the dataset
 info$synapse_table
 }
+
+\dontrun{
+# get help on python cave client
+reticulate::py_help(fac$info$get_datastack_info)
+}
 }

--- a/man/flywire_cave_query.Rd
+++ b/man/flywire_cave_query.Rd
@@ -212,10 +212,15 @@ psp_last=flywire_cave_query(table = 'proofreading_status_public_v1',
 
 \dontrun{
 # timetravel query example
-# note use of allow_missing_lookups=T in cas
+# note use of allow_missing_lookups=T as not infrequently materialisation
+# can fail for a neuron
 cambridge_celltypes_v2.783 <- flywire_cave_query('cambridge_celltypes_v2', version = 783,
   timetravel=TRUE, allow_missing_lookups=TRUE,
   select_columns = list(cambridge_celltypes_v2=c("id", "tag", "pt_root_id", "pt_supervoxel_id")))
+
+# querying by regex on a cell type in this table
+mbon012<- flywire_cave_query('cambridge_celltypes_v2', version = 783,
+timetravel=TRUE, allow_missing_lookups=TRUE, filter_regex_dict = c(tag='MBON0[12]'))
 }
 }
 \seealso{

--- a/man/flywire_cave_query.Rd
+++ b/man/flywire_cave_query.Rd
@@ -39,6 +39,10 @@ selects \code{Live live} mode which gives access even to annotations that
 are not part of a materialisation version. See section \bold{Live and Live
 Live queries} for details.}
 
+\item{timetravel}{Whether to interpret \code{version}/\code{timestamp} as a
+defined point in the past to which the very \emph{latest} annotations will
+be sent back in time, recalculating root ids as necessary.}
+
 \item{filter_in_dict, filter_out_dict}{Optional arguments consisting of key
 value lists that restrict the returned rows (keeping only matches or
 filtering out matches). Commonly used to selected rows for specific
@@ -132,6 +136,14 @@ CAVE (Connectome Annotation Versioning Engine) provides a shared
   materialisation version.
 
   }
+
+  We have found that these different query modes do not cover all of our use
+  cases. In particular we often want to be able to travel \emph{backwards} in
+  time, taking a current annotation table and mapping the root_ids onto an
+  earlier state of the segmentation. You can access this functionality by
+  setting the \code{timetravel} argument. Under the hood this uses a live
+  live query using a now timestamp, followed by translating all root ids back
+  to their earlier state using the associated supervoxel ids.
 }
 
 \section{CAVE Views}{

--- a/man/flywire_cave_query.Rd
+++ b/man/flywire_cave_query.Rd
@@ -105,6 +105,21 @@ CAVE (Connectome Annotation Versioning Engine) provides a shared
   }
 }
 
+\section{Live and Live Live queries}{
+ CAVE versions both root ids in the
+  segmentation and annotation tables with the same versioning system. This is
+  not really ideal as annotation can keep on evolving even though the
+  segmentation is static. There are two options to \emph{time travel}
+  annotations to a different point in time. Live queries take the contents of
+  a table at some version and update the root ids to match a different
+  timepoint (usually now). However the set of annotations remains stuck at
+  the selected version.
+
+  Live Live mode (CAVE terminology, \code{live=2}) allows a table to contain
+  the latest set of annotations and to have ids time travel to a selected
+  timepoint.
+}
+
 \section{CAVE Views}{
  In addition to regular database tables, CAVE provides
   support for \bold{views}. These are based on a SQL query which typically

--- a/man/flywire_cave_query.Rd
+++ b/man/flywire_cave_query.Rd
@@ -13,6 +13,7 @@ flywire_cave_query(
   timetravel = FALSE,
   filter_in_dict = NULL,
   filter_out_dict = NULL,
+  filter_regex_dict = NULL,
   select_columns = NULL,
   offset = 0L,
   limit = NULL,
@@ -43,10 +44,10 @@ Live queries} for details.}
 defined point in the past to which the very \emph{latest} annotations will
 be sent back in time, recalculating root ids as necessary.}
 
-\item{filter_in_dict, filter_out_dict}{Optional arguments consisting of key
-value lists that restrict the returned rows (keeping only matches or
-filtering out matches). Commonly used to selected rows for specific
-neurons. See examples and CAVE documentation for details.}
+\item{filter_in_dict, filter_out_dict, filter_regex_dict}{Optional arguments
+consisting of key value lists that restrict the returned rows (keeping only
+matches or filtering out matches). Commonly used to selected rows for
+specific neurons. See examples and CAVE documentation for details.}
 
 \item{select_columns}{Either a character vector naming columns or a python
 dict (required if the query involves multiple tables).}
@@ -207,6 +208,14 @@ lastv=tail(fcc$materialize$get_versions(), n=1)
 # pull that
 psp_last=flywire_cave_query(table = 'proofreading_status_public_v1',
   version=lastv)
+}
+
+\dontrun{
+# timetravel query example
+# note use of allow_missing_lookups=T in cas
+cambridge_celltypes_v2.783 <- flywire_cave_query('cambridge_celltypes_v2', version = 783,
+  timetravel=TRUE, allow_missing_lookups=TRUE,
+  select_columns = list(cambridge_celltypes_v2=c("id", "tag", "pt_root_id", "pt_supervoxel_id")))
 }
 }
 \seealso{

--- a/man/flywire_cave_query.Rd
+++ b/man/flywire_cave_query.Rd
@@ -9,7 +9,8 @@ flywire_cave_query(
   datastack_name = getOption("fafbseg.cave.datastack_name", "flywire_fafb_production"),
   version = NULL,
   timestamp = NULL,
-  live = is.null(version) && is.null(timestamp),
+  live = is.null(version),
+  timetravel = FALSE,
   filter_in_dict = NULL,
   filter_out_dict = NULL,
   select_columns = NULL,
@@ -32,11 +33,11 @@ and examples.}
 UTC when no timezone is specified.}
 
 \item{live}{Whether to use live query mode, which updates any root ids to
-their current value (or to a specified \code{timestamp}). \code{TRUE} or
-\code{1} selected CAVE's \emph{Live} mode, while \code{2} selects
-\code{Live live} mode which gives access even to annotations that are not
-part of a materialisation version. See section \bold{Live and Live Live
-queries} for details.}
+their current value (or to another \code{timestamp} when provided). Values
+of \code{TRUE} or \code{1} select CAVE's \emph{Live} mode, while \code{2}
+selects \code{Live live} mode which gives access even to annotations that
+are not part of a materialisation version. See section \bold{Live and Live
+Live queries} for details.}
 
 \item{filter_in_dict, filter_out_dict}{Optional arguments consisting of key
 value lists that restrict the returned rows (keeping only matches or

--- a/man/flywire_cave_query.Rd
+++ b/man/flywire_cave_query.Rd
@@ -32,7 +32,11 @@ and examples.}
 UTC when no timezone is specified.}
 
 \item{live}{Whether to use live query mode, which updates any root ids to
-their current value.}
+their current value (or to a specified \code{timestamp}). \code{TRUE} or
+\code{1} selected CAVE's \emph{Live} mode, while \code{2} selects
+\code{Live live} mode which gives access even to annotations that are not
+part of a materialisation version. See section \bold{Live and Live Live
+queries} for details.}
 
 \item{filter_in_dict, filter_out_dict}{Optional arguments consisting of key
 value lists that restrict the returned rows (keeping only matches or
@@ -106,18 +110,27 @@ CAVE (Connectome Annotation Versioning Engine) provides a shared
 }
 
 \section{Live and Live Live queries}{
- CAVE versions both root ids in the
-  segmentation and annotation tables with the same versioning system. This is
-  not really ideal as annotation can keep on evolving even though the
-  segmentation is static. There are two options to \emph{time travel}
-  annotations to a different point in time. Live queries take the contents of
-  a table at some version and update the root ids to match a different
-  timepoint (usually now). However the set of annotations remains stuck at
-  the selected version.
+ CAVE versions the segmentation and
+  annotation tables with shared version numbers. When a dataset is stable,
+  using this single version works well. However, we have found that this
+  arrangement is not ideal in many situations, as annotations often evolve
+  even though the segmentation is static.
 
-  Live Live mode (CAVE terminology, \code{live=2}) allows a table to contain
-  the latest set of annotations and to have ids time travel to a selected
-  timepoint.
+  CAVE has two options to update annotations to a different point in time:
+  \enumerate{
+
+  \item \bold{Live queries} take the contents of a table at some version and
+  updates the root ids to match a later timepoint (usually now). However the
+  set of annotations remains stuck at the selected version. The starting
+  materialisation version is chosen to be the most recent one preceding the
+  requested timepoint.
+
+  \item \bold{Live live queries} (CAVE terminology, \code{live=2}) can return
+  the state of an annotation table at an arbitrary timepoint. This includes
+  annotations that have not yet been incorporated into a released
+  materialisation version.
+
+  }
 }
 
 \section{CAVE Views}{

--- a/tests/testthat/test-cave.R
+++ b/tests/testthat/test-cave.R
@@ -45,6 +45,12 @@ test_that("cave query", {
                      filter_in_dict = list(pt_root_id=mbon012.ids), version=783L)$tag,
             c("MBON01", "MBON02"))
 
+  expect_in(flywire_cave_query(
+    table = 'cambridge_celltypes_v2',
+    filter_in_dict = list(pt_root_id=mbon012.ids),
+    version=783L, live = 2, allow_missing_lookups=T)$tag,
+            c("MBON01", "MBON02"))
+
   expect_warning(expect_error(
     flywire_cave_query("cambridge_celltypes_v2", version=783, timetravel = T,
       filter_regex_dict = c(tag='MBON0[12]'),

--- a/tests/testthat/test-cave.R
+++ b/tests/testthat/test-cave.R
@@ -26,6 +26,37 @@ test_that("cave query", {
     res2, res[1,]
   )
 
+  expect_true(nrow(pnv10 <- flywire_cave_query('proofread_neurons_view', limit = 10))==10)
+  expect_equal(
+    flywire_cave_query('proofread_neurons_view', limit = 10, version = 'latest'),
+    pnv10)
+
+  expect_error(flywire_cave_query('proofread_neurons_view', limit = 10, timestamp = 'now'))
+
+  expect_warning(expect_s3_class(class = 'data.frame',
+    mbon012 <- flywire_cave_query("cambridge_celltypes_v2", version=783, timetravel = T,
+                       filter_regex_dict = c(tag='MBON0[12]'))
+    ))
+
+  expect_in(mbon012$pt_root_id,
+            mbon012.ids <- flywire_ids('/type:MBON0[12]', version = 783, use_static=T))
+
+  expect_in(flywire_cave_query('cambridge_celltypes_v2',
+                     filter_in_dict = list(pt_root_id=mbon012.ids), version=783L)$tag,
+            c("MBON01", "MBON02"))
+
+  expect_warning(expect_error(
+    flywire_cave_query("cambridge_celltypes_v2", version=783, timetravel = T,
+      filter_regex_dict = c(tag='MBON0[12]'),
+      select_columns = c("id", "pt_root_id", "tag"))
+  ))
+
+  expect_silent(
+    flywire_cave_query("cambridge_celltypes_v2", version=783, timetravel = T,
+                       filter_regex_dict = list(cambridge_celltypes_v2=list(tag='MBON0[12]')),
+                       select_columns = list(cambridge_celltypes_v2=c("id", "pt_root_id", "pt_supervoxel_id","tag")))
+  )
+
 })
 
 test_that("flywire_timestamp", {

--- a/tests/testthat/test-flywire.R
+++ b/tests/testthat/test-flywire.R
@@ -134,10 +134,13 @@ test_that("can get root ids", {
   skip_if_not(reticulate::py_module_available("cloudvolume"),
               "Skipping live flywire tests requiring python cloudvolume module")
 
-  svids=c("81489548781649724", "80011805220634701", "0")
-  expect_length(rootids <- flywire_rootid(svids), 3L)
+  svids=c("81489548781649724", "80011805220634701", "80011805220634701", "0")
+  expect_length(rootids <- flywire_rootid(svids), 4L)
   expect_is(rootids, 'character')
-  expect_match(rootids[1:2], "^7[0-9]{17}")
+  expect_match(rootids[1:3], "^7[0-9]{17}")
+  expect_equal(
+    flywire_rootid(svids, method = 'cave', integer64 = T, version=526, cache = T),
+    rootids)
 
   expect_equal(flywire_rootid(svids, method = 'cloudvolume'),
                flywire_rootid(svids, method = 'flywire'))


### PR DESCRIPTION
* implements time travel of livelive annotations back to older segmentation versions
* also includes two important bug fixes in flywire_rootid