### PR TITLE
Small speed up in writing to flywire_leaves cache

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,7 +77,7 @@ Suggests:
     dbplyr,
     ggplot2,
     brotli,
-    cachem,
+    cachem (>= 1.0.7),
     arrow,
     glue,
     lubridate,

--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -539,7 +539,9 @@ flywire_leaves_cache <- memoise::memoise(function(
   check_package_available('cachem')
   # so we can use cachedir for other caches.
   if(isTRUE(nzchar(cachedir))) cachedir=file.path(cachedir, subdir)
-  d <- cachem::cache_disk(max_size = cachesize, dir = cachedir)
+  # don't gzip on top of brotli
+  writenogz=function(...) saveRDS(..., compress = F)
+  d <- cachem::cache_disk(max_size = cachesize, dir = cachedir, write_fn = writenogz)
   if(isTRUE(hybrid)) {
     # unclear that mem cache gives any useful benefit given compression cycle
     m <- cachem::cache_mem(max_size = 200 * 1024^2)


### PR DESCRIPTION
* skip pointless gzip compression (since we already compress with brotli)
* using qs::qsave with default parameters could have saved 5x on write and 2x on read, but decided it wasn't worth it.
* sorting leaves would have save 25-30% space
* but decided not to implement either of these for consistency.