### PR TITLE
flywire_xyz2id: use flywire_voxdims() for default

### DIFF
--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -825,7 +825,7 @@ flywire_latestid <- function(rootid, sample=100L, level=2L,
 #' # now look up the root ids - very fast with method="cloudvolume", the default
 #' flywire_rootid(svids)
 #' }
-flywire_xyz2id <- function(xyz, rawcoords=FALSE, voxdims=c(4,4,40),
+flywire_xyz2id <- function(xyz, rawcoords=FALSE, voxdims=flywire_voxdims(),
                            cloudvolume.url=NULL,
                            root=TRUE,
                            timestamp=NULL,

--- a/R/flywire-api.R
+++ b/R/flywire-api.R
@@ -736,7 +736,9 @@ flywire_latestid <- function(rootid, sample=100L, level=2L,
 #'   compatible with \code{\link{xyzmatrix}} including \code{neuron} or
 #'   \code{mesh3d} surface objects.
 #' @param rawcoords whether the input values are raw voxel indices or in nm
-#' @param voxdims voxel dimensions in nm used to convert raw coordinates.
+#' @param voxdims voxel dimensions in nm used to convert raw coordinates. The
+#'   default value uses the \code{\link{flywire_voxdims}} function to identify
+#'   the value for the current segmentation (usually with success).
 #' @param cloudvolume.url URL for CloudVolume to fetch segmentation image data.
 #'   The default value of NULL chooses the flywire production segmentation
 #'   dataset.

--- a/man/flywire_updateids.Rd
+++ b/man/flywire_updateids.Rd
@@ -27,7 +27,9 @@ flywire_updateids(
 
 \item{rawcoords}{whether the input values are raw voxel indices or in nm}
 
-\item{voxdims}{voxel dimensions in nm used to convert raw coordinates.}
+\item{voxdims}{voxel dimensions in nm used to convert raw coordinates. The
+default value uses the \code{\link{flywire_voxdims}} function to identify
+the value for the current segmentation (usually with success).}
 
 \item{cache}{Whether to cache supervoxel id to root id mappings. The default
 value of \code{NA} will do this when a version or timestamp argument is

--- a/man/flywire_xyz2id.Rd
+++ b/man/flywire_xyz2id.Rd
@@ -7,7 +7,7 @@
 flywire_xyz2id(
   xyz,
   rawcoords = FALSE,
-  voxdims = c(4, 4, 40),
+  voxdims = flywire_voxdims(),
   cloudvolume.url = NULL,
   root = TRUE,
   timestamp = NULL,
@@ -26,7 +26,9 @@ compatible with \code{\link{xyzmatrix}} including \code{neuron} or
 
 \item{rawcoords}{whether the input values are raw voxel indices or in nm}
 
-\item{voxdims}{voxel dimensions in nm used to convert raw coordinates.}
+\item{voxdims}{voxel dimensions in nm used to convert raw coordinates. The
+default value uses the \code{\link{flywire_voxdims}} function to identify
+the value for the current segmentation (usually with success).}
 
 \item{cloudvolume.url}{URL for CloudVolume to fetch segmentation image data.
 The default value of NULL chooses the flywire production segmentation


### PR DESCRIPTION
* have been caught a few times now when an incorrect voxel size was used
* which seems a shame since we have a way to figure out the correct size