### PR TITLE
Fix/flytable delta sync

### DIFF
--- a/R/flytable-cache.R
+++ b/R/flytable-cache.R
@@ -247,9 +247,11 @@ flytable_delta_sync <- function(cached_data, table, oldmtime, base = NULL,
       rowidxs <- match(modrows[["_id"]], res[["_id"]])
       isnew <- is.na(rowidxs)
 
-      # Update existing rows
+      # Update existing rows — explicitly specify columns to avoid R's
+      # [<-.data.frame bug with whole-row assignment and POSIXct columns
       if (!all(isnew)) {
-        res[na.omit(rowidxs), ] <- modrows[!isnew, , drop = FALSE]
+        cols <- colnames(modrows)
+        res[na.omit(rowidxs), cols] <- modrows[!isnew, cols, drop = FALSE]
       }
 
       # Append new rows

--- a/R/flytable-cache.R
+++ b/R/flytable-cache.R
@@ -214,7 +214,7 @@ flytable_delta_sync <- function(cached_data, table, oldmtime, base = NULL,
 
   if (has_modifications) {
     # Fetch modified rows since last sync
-    qq <- glue::glue("select * from {table} where datedif(`_mtime`, '{oldmtime}', 'S') < 0")
+    qq <- glue::glue("select * from {table} where datedif('{oldmtime}', `_mtime`, 'S') >= 0")
     modrows <- suppressWarnings(flytable_query(qq, base = base,
                                                collapse_lists = collapse_lists,
                                                limit = limit))

--- a/R/flytable-cache.R
+++ b/R/flytable-cache.R
@@ -156,9 +156,14 @@ flytable_cached_table <- function(table, expiry = 300, refresh = FALSE,
                                    collapse_lists = collapse_lists, base = base,
                                    limit = limit))
     }
-    # Connection or other error - return cached data with warning
+    # Connection or other error - return stale cached data with warning
+    cached_age <- tryCatch({
+      ct <- flytable_parse_date(oldmtime, format = 'timestamp')
+      format(round(difftime(Sys.time(), ct, units = 'hours'), 1))
+    }, error = function(e2) "unknown")
     warning("Delta sync failed for '", table, "': ", conditionMessage(e),
-            "\nReturning cached data from ", oldmtime)
+            "\nReturning stale cached data (", nrow(res), " rows, ",
+            cached_age, " old). Use refresh=TRUE to force a full re-download.")
     res
   })
 }
@@ -203,8 +208,11 @@ flytable_delta_sync <- function(cached_data, table, oldmtime, base = NULL,
   cached_time <- flytable_parse_date(oldmtime, format = 'timestamp')
   server_max_time <- flytable_parse_date(max_mtime, format = 'timestamp')
 
-  # Check if any modifications occurred since last sync
-  has_modifications <- server_max_time > cached_time
+  # Check if any modifications occurred since last sync.
+  # max(_mtime) from seatable lacks sub-second precision while oldmtime from
+  # now() has nanoseconds, so truncate cached_time to seconds to avoid missing
+  # changes that fall within the same second.
+  has_modifications <- server_max_time >= trunc(cached_time, units = 'secs')
 
   # Calculate potential deletions from row count
   n_original <- nrow(cached_data)
@@ -214,10 +222,21 @@ flytable_delta_sync <- function(cached_data, table, oldmtime, base = NULL,
 
   if (has_modifications) {
     # Fetch modified rows since last sync
-    qq <- glue::glue("select * from {table} where datedif('{oldmtime}', `_mtime`, 'S') >= 0")
-    modrows <- suppressWarnings(flytable_query(qq, base = base,
-                                               collapse_lists = collapse_lists,
-                                               limit = limit))
+    # Truncate fractional seconds since datedif operates at second resolution.
+    sync_from <- sub("\\.\\d+", "", oldmtime)
+    qq <- glue::glue("select * from {table} where datedif('{sync_from}', `_mtime`, 'S') >= 0")
+    modrows <- tryCatch(
+      flytable_query(qq, base = base, collapse_lists = collapse_lists,
+                     limit = limit),
+      warning = function(w) {
+        # "No rows returned" is expected when has_modifications is based on
+        # updates to existing rows only (no new _mtime > cached_time rows
+        # survive the query). Other warnings should propagate.
+        if (!grepl("No rows returned", conditionMessage(w)))
+          warning(w)
+        NULL
+      }
+    )
 
     if (!is.null(modrows) && nrow(modrows) > 0) {
       # Check for schema changes
@@ -239,6 +258,11 @@ flytable_delta_sync <- function(cached_data, table, oldmtime, base = NULL,
         # Adjust deletion estimate for new rows
         n_deleted_estimate <- n_deleted_estimate + sum(isnew)
       }
+    } else if (n_original != n_total) {
+      # has_modifications was TRUE but query returned nothing — likely a
+      # datedif or timestamp format problem
+      warning("Delta sync for '", table, "': server reports modifications but ",
+              "datedif query returned 0 rows. Use refresh=TRUE to force a full re-download.")
     }
   }
 
@@ -247,7 +271,18 @@ flytable_delta_sync <- function(cached_data, table, oldmtime, base = NULL,
     res <- flytable_remove_deleted(res, table)
   }
 
-  attr(res, 'mtime') <- mtime
+  # Verify sync completeness before updating mtime
+  if (nrow(res) != n_total) {
+    warning("Delta sync for '", table, "' row count mismatch: ",
+            nrow(res), " local vs ", n_total, " remote. Forcing full refresh.")
+    res <- flytable_full_fetch(table, base = base,
+                               collapse_lists = collapse_lists, limit = limit)
+    if (is.null(res)) {
+      stop("Full refresh failed for '", table, "'")
+    }
+  } else {
+    attr(res, 'mtime') <- mtime
+  }
   res
 }
 

--- a/R/flytable-cache.R
+++ b/R/flytable-cache.R
@@ -22,16 +22,16 @@ flytable_now <- function(table='info') {
 #' @noRd
 flytable_sync_metadata <- function(table) {
   res <- flytable_query(
-    paste('select max(now()), count(_id), max(_mtime) from', table)
+    paste('select max(now()) as `server_now`, count(_id) as `row_count`, max(_mtime) as `max_mtime` from', table)
   )
   if (!is.data.frame(res) || nrow(res) == 0) {
     stop("Unable to fetch sync metadata from flytable")
   }
 
   list(
-    now = res[[1]],
-    nrow = res[[2]],
-    max_mtime = res[[3]]
+    now = res[["server_now"]],
+    nrow = as.integer(res[["row_count"]]),
+    max_mtime = res[["max_mtime"]]
   )
 }
 

--- a/tests/testthat/test-flytable.R
+++ b/tests/testthat/test-flytable.R
@@ -108,6 +108,50 @@ test_that("read only shared tables", {
 })
 
 
+test_that("delta sync timestamp handling is correct", {
+  # Truncating fractional seconds for datedif query
+  mtime_nano <- "2026-03-27T14:36:41.382928045Z"
+  sync_from <- sub("\\.\\d+", "", mtime_nano)
+  expect_equal(sync_from, "2026-03-27T14:36:41Z")
+
+  # No fractional seconds — unchanged
+  mtime_whole <- "2026-03-27T14:36:41Z"
+  expect_equal(sub("\\.\\d+", "", mtime_whole), mtime_whole)
+
+  # has_modifications comparison: truncated cached_time should not miss
+  # same-second modifications (max_mtime lacks sub-second precision)
+  cached_time <- fafbseg:::flytable_parse_date(mtime_nano, format = 'timestamp')
+  max_mtime <- fafbseg:::flytable_parse_date("2026-03-27T14:36:41Z", format = 'timestamp')
+
+  # Without truncation, this would be FALSE (sub-second precision makes cached > max)
+  expect_false(max_mtime > cached_time)
+  # With truncation, same-second is caught
+  expect_true(max_mtime >= trunc(cached_time, units = 'secs'))
+})
+
+
+test_that("delta sync row update handles POSIXct columns", {
+  # R's [<-.data.frame with whole-row assignment fails with mixed POSIXct/other
+  # columns. Explicitly specifying columns avoids the bug.
+  cached <- data.frame(
+    id = c("a", "b", "c"),
+    value = 1:3,
+    mtime = as.POSIXct(c("2026-01-01", "2026-01-02", "2026-01-03"), tz = "UTC"),
+    stringsAsFactors = FALSE
+  )
+  fresh <- data.frame(
+    id = "b",
+    value = 99L,
+    mtime = as.POSIXct("2026-03-27", tz = "UTC"),
+    stringsAsFactors = FALSE
+  )
+  cols <- colnames(fresh)
+  cached[2, cols] <- fresh[1, cols, drop = FALSE]
+  expect_equal(cached$value[2], 99L)
+  expect_equal(cached$mtime[2], as.POSIXct("2026-03-27", tz = "UTC"))
+})
+
+
 test_that("flytable_cached_table works", {
   ac <- try(flytable_login())
   skip_if(inherits(ac, 'try-error'),

--- a/tests/testthat/test-flytable.R
+++ b/tests/testthat/test-flytable.R
@@ -119,7 +119,8 @@ test_that("flytable_cached_table works", {
 
   # Clear any existing cache for testfruit
   fc <- fafbseg:::flytable_cache()
-  fc$remove('testfruit')
+  cache_key <- fafbseg:::flytable_cache_key('testfruit')
+  fc$remove(cache_key)
 
   # Test 1: Basic fetch (cache miss)
   fruit1 <- flytable_cached_table('testfruit')
@@ -148,6 +149,46 @@ test_that("flytable_cached_table works", {
   expect_true(nchar(mtime) > 10)  # Should be a proper timestamp string
 
   # Cleanup
+  fc$remove(cache_key)
+})
 
-  fc$remove('testfruit')
+
+test_that("flytable_cached_table delta sync picks up new rows", {
+  ac <- try(flytable_login())
+  skip_if(inherits(ac, 'try-error'),
+          "skipping delta sync test as unable to login!")
+
+  fat <- try(flytable_alltables())
+  skip_if(inherits(fat, 'try-error'),
+          "skipping delta sync test as having trouble listing all tables!")
+
+  fc <- fafbseg:::flytable_cache()
+  cache_key <- fafbseg:::flytable_cache_key('testfruit')
+  fc$remove(cache_key)
+
+  # Baseline: full fetch
+  fruit_before <- flytable_cached_table('testfruit')
+  n_before <- nrow(fruit_before)
+
+  # Append a row with a unique nid to avoid collisions
+  nid <- sample.int(1e7, size = 1)
+  flytable_append_rows(
+    table = 'testfruit',
+    data.frame(fruit_name = 'dragonfruit', person = 'Delta Sync Test', nid = nid))
+
+  # Delta sync should pick up the new row
+  fruit_after <- flytable_cached_table('testfruit', expiry = 0)
+  expect_equal(nrow(fruit_after), n_before + 1L)
+  expect_true(any(fruit_after$nid == nid))
+
+  # Verify mtime was updated (sync was complete)
+  expect_true(attr(fruit_after, 'mtime') != attr(fruit_before, 'mtime'))
+
+  # Cleanup: delete the test row
+  iddf <- flytable_query(
+    glue::glue("SELECT `_id` FROM testfruit WHERE person='Delta Sync Test' AND nid={nid}"))
+  if (nrow(iddf) > 0) {
+    flytable_delete_rows(iddf[['_id']], table = 'testfruit', DryRun = FALSE)
+  }
+  fc$remove(cache_key)
 })


### PR DESCRIPTION
There were at least two serious bugs with the delta sync logic. One of these was a surprising bug on the seatable side (dateDif only works in one direction) which in turn meant that no updates were happening after an initial cache. The second related to fetching the number of rows and modification timestamps - the sql query returned columns in an arbitrary order so sometimes the timestamp was actually the number of rows or vice versa.