### PR TITLE
Allow downstream packages to redirect flytable to alternative seatable

### DIFF
--- a/R/fafbseg-package.R
+++ b/R/fafbseg-package.R
@@ -47,6 +47,15 @@
 #'   or larger to speed things up. See \code{\link{brainmaps_xyz2id}} for
 #'   details.
 #'
+#'   \item{\code{fafbseg.flytable.url}} the seatable server URL used by
+#'   \code{\link{flytable_login}}, \code{\link{flytable_base}} and downstream
+#'   helpers including \code{\link{cam_meta}} and
+#'   \code{\link{flytable_cached_table}}. Defaults to
+#'   \code{"https://flytable.mrc-lmb.cam.ac.uk/"}. Setting this option (e.g.
+#'   inside a \code{withr::with_options()} block) lets downstream packages
+#'   point the flytable infrastructure at an alternative seatable instance
+#'   without having to thread the URL through every call site.
+#'
 #'   }
 #'
 #' @examples

--- a/R/flytable-cam.R
+++ b/R/flytable-cam.R
@@ -16,6 +16,12 @@
 #'   There is no special logic in choosing which rows to drop, but the dropped
 #'   rows are retained as an attribute on the table with a warning so that you
 #'   can inspect.
+#' @param token Optional API token. When supplied, the \code{FLYTABLE_TOKEN}
+#'   environment variable is temporarily set to this value for the duration of
+#'   the call (and restored on exit) so you can authenticate against an
+#'   alternative seatable instance without permanently overwriting your token.
+#'   Typically used in combination with the \code{fafbseg.flytable.url}
+#'   \link[=fafbseg-package]{package option}.
 #' @param ... Additional arguments passed to \code{\link{flytable_cached_table}}
 #'   (e.g. \code{expiry}, \code{refresh}) which can be used to control details
 #'   of the cache strategy.
@@ -47,7 +53,11 @@
 #' }
 cam_meta <- function(ids=NULL, ignore.case = F, fixed = F, table='aedes_main',
                      base=NULL,
-                     version=NULL, timestamp=NULL, unique=FALSE, ...) {
+                     version=NULL, timestamp=NULL, unique=FALSE,
+                     token=NULL, ...) {
+
+  if (!is.null(token))
+    withr::local_envvar(FLYTABLE_TOKEN = token)
 
   if(is.character(ids) && length(ids)==1 && !fafbseg:::valid_id(ids) && substr(ids,1,1)=="/")
     ids=substr(ids,2, nchar(ids))

--- a/R/flytable.R
+++ b/R/flytable.R
@@ -52,7 +52,8 @@ check_seatable<- memoise::memoise(function(min_version=NULL) {
 #' \dontrun{
 #' flytable_login()
 #' }
-flytable_login <- function(url='https://flytable.mrc-lmb.cam.ac.uk/',
+flytable_login <- function(url=getOption("fafbseg.flytable.url",
+                                         'https://flytable.mrc-lmb.cam.ac.uk/'),
                            token=Sys.getenv("FLYTABLE_TOKEN", unset = NA_character_)) {
   st<-check_seatable()
   if(is.na(token)) {
@@ -77,7 +78,9 @@ flytable_login <- function(url='https://flytable.mrc-lmb.cam.ac.uk/',
 #' \dontrun{
 #' flytable_set_token(user='xxx@gmail.com', pwd='yyy')
 #' }
-flytable_set_token <- function(user, pwd, url='https://flytable.mrc-lmb.cam.ac.uk/') {
+flytable_set_token <- function(user, pwd,
+                               url=getOption("fafbseg.flytable.url",
+                                             'https://flytable.mrc-lmb.cam.ac.uk/')) {
   st<-check_seatable()
   ac<-reticulate::py_call(st$Account, login_name=user , password = pwd,
                       server_url = url)
@@ -91,7 +94,7 @@ flytable_set_token <- function(user, pwd, url='https://flytable.mrc-lmb.cam.ac.u
 }
 
 flytable_base_impl <- memoise::memoise(function(base_name=NULL, table=NULL, url, workspace_id=NULL) {
-  ac=flytable_login()
+  ac=flytable_login(url=url)
   if(is.null(base_name) && is.null(table))
     stop("you must supply one of base or table name!")
   if(is.null(base_name)) {
@@ -145,7 +148,8 @@ flytable_base_impl <- memoise::memoise(function(base_name=NULL, table=NULL, url,
 #'
 flytable_base <- function(table=NULL, base_name=NULL,
                                            workspace_id=NULL,
-                                           url='https://flytable.mrc-lmb.cam.ac.uk/',
+                                           url=getOption("fafbseg.flytable.url",
+                                                         'https://flytable.mrc-lmb.cam.ac.uk/'),
                                            cached=TRUE) {
   if (!cached)
     memoise::forget(flytable_base_impl)

--- a/man/cam_meta.Rd
+++ b/man/cam_meta.Rd
@@ -13,6 +13,7 @@ cam_meta(
   version = NULL,
   timestamp = NULL,
   unique = FALSE,
+  token = NULL,
   ...
 )
 }
@@ -39,6 +40,13 @@ UTC. The special value of \code{'now'} means the current time in UTC.}
 There is no special logic in choosing which rows to drop, but the dropped
 rows are retained as an attribute on the table with a warning so that you
 can inspect.}
+
+\item{token}{Optional API token. When supplied, the \code{FLYTABLE_TOKEN}
+environment variable is temporarily set to this value for the duration of
+the call (and restored on exit) so you can authenticate against an
+alternative seatable instance without permanently overwriting your token.
+Typically used in combination with the \code{fafbseg.flytable.url}
+\link[=fafbseg-package]{package option}.}
 
 \item{...}{Additional arguments passed to \code{\link{flytable_cached_table}}
 (e.g. \code{expiry}, \code{refresh}) which can be used to control details

--- a/man/fafbseg-package.Rd
+++ b/man/fafbseg-package.Rd
@@ -57,6 +57,15 @@ Functions that read some of the raw data formats produced by Google electron mic
   or larger to speed things up. See \code{\link{brainmaps_xyz2id}} for
   details.
 
+  \item{\code{fafbseg.flytable.url}} the seatable server URL used by
+  \code{\link{flytable_login}}, \code{\link{flytable_base}} and downstream
+  helpers including \code{\link{cam_meta}} and
+  \code{\link{flytable_cached_table}}. Defaults to
+  \code{"https://flytable.mrc-lmb.cam.ac.uk/"}. Setting this option (e.g.
+  inside a \code{withr::with_options()} block) lets downstream packages
+  point the flytable infrastructure at an alternative seatable instance
+  without having to thread the URL through every call site.
+
   }
 }
 

--- a/man/flytable_login.Rd
+++ b/man/flytable_login.Rd
@@ -9,17 +9,21 @@
 \title{Low level functions to access the flytable metadata service}
 \usage{
 flytable_login(
-  url = "https://flytable.mrc-lmb.cam.ac.uk/",
+  url = getOption("fafbseg.flytable.url", "https://flytable.mrc-lmb.cam.ac.uk/"),
   token = Sys.getenv("FLYTABLE_TOKEN", unset = NA_character_)
 )
 
-flytable_set_token(user, pwd, url = "https://flytable.mrc-lmb.cam.ac.uk/")
+flytable_set_token(
+  user,
+  pwd,
+  url = getOption("fafbseg.flytable.url", "https://flytable.mrc-lmb.cam.ac.uk/")
+)
 
 flytable_base(
   table = NULL,
   base_name = NULL,
   workspace_id = NULL,
-  url = "https://flytable.mrc-lmb.cam.ac.uk/",
+  url = getOption("fafbseg.flytable.url", "https://flytable.mrc-lmb.cam.ac.uk/"),
   cached = TRUE
 )
 


### PR DESCRIPTION
## Summary
- Add `fafbseg.flytable.url` package option, consumed by `flytable_login` / `flytable_set_token` / `flytable_base`, so downstream packages (e.g. crantr) can point flytable infrastructure at an alternative seatable instance without threading the URL through every call site.
- Fix `flytable_base_impl` to forward `url` to `flytable_login` (previously hard-coded the LMB default).
- Add `token` argument to `cam_meta()` that temporarily swaps `FLYTABLE_TOKEN` via `withr::local_envvar` for the duration of the call, so callers can authenticate against the alternative seatable without permanently overwriting their token.

## Test plan
- [ ] `devtools::check()` passes
- [ ] `cam_meta()` still works against the default LMB seatable
- [ ] With `options(fafbseg.flytable.url = "https://cloud.seatable.io/")` and a `token=` value, `cam_meta(table="CRANTb_meta", ...)` resolves against the CRANTb base