### PR TITLE
Flatten uniform object-dtype columns in pandas2df_inmem

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -738,6 +738,29 @@ pandas2df_inmem <- function(df, tibble = FALSE) {
       res[[col]] <- i64
   }
 
+  # Object dtype: each cell can be an arbitrary Python object. reticulate's
+  # default conversion returns a list of length-1 R vectors even when every
+  # cell is the same scalar type (e.g. a Python `int` per row -- the shape
+  # caveclient's get_l2data_table uses for declared-scalar columns when
+  # mixed with array-valued ones). Detect that case and flatten to an atomic
+  # vector. For integer-valued cells we read via series.map(str).tolist() so
+  # arbitrary-precision Python ints round-trip without int32 truncation.
+  object_cols <- names(dtypes)[tolower(dtypes) == "object"]
+  for(col in intersect(object_cols, names(res))) {
+    x <- res[[col]]
+    if(!is.list(x)) next
+    lens <- lengths(x)
+    if(!all(lens <= 1L)) next                       # heterogeneous, leave alone
+    if(all(lens == 0L)) {                           # all NA
+      res[[col]] <- rep(NA, length(x))
+      next
+    }
+    series <- reticulate::py_get_item(df, col)
+    flat <- pandas_object_series_to_vector(series)
+    if(!is.null(flat))
+      res[[col]] <- flat
+  }
+
   datetime_cols <- names(dtypes)[grepl("^datetime", dtypes)]
   posix_list_cols <- names(res)[vapply(res, is_posixct_list, logical(1))]
   for(col in intersect(unique(c(datetime_cols, posix_list_cols)), names(res))) {
@@ -789,6 +812,44 @@ pandas_series_integer64 <- function(series, dtype) {
   if(any(int64_overflows(vals), na.rm = TRUE))
     stop("int64 overflow! id cannot be represented as int64")
   bit64::as.integer64(vals)
+}
+
+# Flatten a pandas Series of object dtype whose cells are all the same scalar
+# Python type (or NA) into an atomic R vector. Reads cells as strings via
+# series.map(str).tolist() so arbitrary-precision Python ints round-trip
+# without int32 truncation (the bug that corrupts uint32 columns >= 2^31
+# returned by the L2 cache).
+pandas_object_series_to_vector <- function(series) {
+  classify_object_values(pandas_series_character_values(series))
+}
+
+# Pure-R companion: given a character vector of pandas object cells (each
+# already mapped via str()), classify and convert to the natural atomic R
+# type. Returns NULL when the column can't be classified (mixed types) and
+# the caller should leave the list-column intact.
+classify_object_values <- function(vals) {
+  if(is.null(vals)) return(NULL)
+  present <- !is.na(vals)
+  if(!any(present)) return(rep(NA, length(vals)))   # all-NA: caller's choice
+
+  # Integer-shaped strings -> numeric, or integer64 when beyond 2^53.
+  if(all(grepl("^-?[0-9]+$", vals[present]))) {
+    if(any(int64_overflows(vals), na.rm = TRUE)) return(NULL)
+    nums <- suppressWarnings(as.numeric(vals))
+    # 2^53 is the largest integer exactly representable as double; values >=
+    # 2^53 + 1 silently round when converted via as.numeric.
+    if(all(is.na(nums) | abs(nums) < 2^53)) return(nums)
+    return(bit64::as.integer64(vals))
+  }
+
+  # Float-shaped strings (incl. "nan", "inf", "-inf", scientific notation).
+  # as.numeric returns NA for unparseable strings; require the parse to
+  # introduce no *new* NAs before accepting numeric classification.
+  nums <- suppressWarnings(as.numeric(vals))
+  if(identical(is.na(nums), is.na(vals))) return(nums)
+
+  # Otherwise treat as character vector.
+  vals
 }
 
 pandas_series_character_values <- function(series) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -167,3 +167,43 @@ test_that("internet_ok works", {
   skip_if_offline()
   expect_true(internet_ok())
 })
+
+test_that("classify_object_values flattens uniform-scalar object columns", {
+  # integer-shaped strings -> numeric, including values > 2^31 that would
+  # overflow R int32 if naively converted per-cell (the L2 cache bug)
+  expect_equal(
+    fafbseg:::classify_object_values(c("90040320", "11301120", "3999835136")),
+    c(90040320, 11301120, 3999835136)
+  )
+  # float-shaped strings -> numeric
+  expect_equal(
+    fafbseg:::classify_object_values(c("0.5", "-1.25", "1e3")),
+    c(0.5, -1.25, 1000)
+  )
+  # NAs preserved
+  expect_equal(
+    fafbseg:::classify_object_values(c("1", NA, "3")),
+    c(1, NA, 3)
+  )
+  # all-NA -> NA of unspecified type
+  expect_true(all(is.na(fafbseg:::classify_object_values(c(NA_character_, NA_character_)))))
+})
+
+test_that("classify_object_values returns integer64 for ints beyond 2^53", {
+  vals <- c("9007199254740993", "10")  # 2^53 + 1, just past double precision
+  out  <- fafbseg:::classify_object_values(vals)
+  expect_s3_class(out, "integer64")
+  expect_equal(as.character(out), vals)
+})
+
+test_that("classify_object_values returns NULL on int64 overflow", {
+  # ~10^20 overflows int64; safer to leave the column alone
+  expect_null(fafbseg:::classify_object_values(c("123456789012345678901", "1")))
+})
+
+test_that("classify_object_values falls through to character on mixed content", {
+  expect_equal(
+    fafbseg:::classify_object_values(c("foo", "bar")),
+    c("foo", "bar")
+  )
+})


### PR DESCRIPTION
reticulate's py_to_r() on a pandas object-dtype column returns an R list of length-1 vectors (one element per row) rather than a flat atomic vector, even when every cell is the same scalar Python type. Per-cell conversion also truncates Python ints to R int32, silently corrupting values >= 2^31. The arrow round-trip used to mask both problems but is no longer the default in pandas2df because having two copies of libarrow loaded (Python + R) caused regular crashes.

Symptoms surface clearly in flywire_l2attributes(): caveclient's get_l2data_table() builds the unfiltered DataFrame with plain Python int cells (object dtype), so size_nm3 and area_nm2 come back as <list><int [1]>, with int32 overflow at 2^31 -- and real soma chunks in Aedes neurons have size_nm3 well past that (up to 36.5 GB observed, nearly 9x the uint32 max).

The fix lives in pandas2df_inmem, not in any caller. After the existing int64/uint64 handling, scan object-dtype columns and try to flatten them: read each cell via series.map(str).tolist() (preserving arbitrary precision), classify the values, and substitute an atomic vector when classification succeeds:

* integer-shaped strings  -> numeric (or bit64::integer64 beyond 2^53)
* float-shaped strings    -> numeric
* anything else uniform   -> character
* mixed / non-scalar      -> leave as list

The string round-trip means values that exceed uint32 max (where my earlier x+2^32 reinterpretation would have been wrong) come through correctly without any width-specific logic.

classify_object_values() is the pure-R worker, unit-tested offline. pandas_object_series_to_vector() is the pandas-aware wrapper used by pandas2df_inmem.