### PR TITLE
Chunk vcache_mset to avoid bit64 as.list protection overflow

### DIFF
--- a/R/autosyn.R
+++ b/R/autosyn.R
@@ -371,6 +371,8 @@ spine_svids2synapses <- function(svids, Verbose, partners, details=FALSE) {
 #'   \code{\link[rgl]{as.mesh3d}} can handle including \code{\link[nat]{hxsurf}} and
 #'   \code{\link[nat]{boundingbox}} objects. See \code{\link[nat]{pointsinside}} for
 #'   details.
+#' @param invert_surf When \code{TRUE}, select partners whose presynaptic
+#'   position lies \emph{outside} the \code{surf} ROI rather than inside.
 #' @param remove_autapses For \code{flywire_partner_summary} whether to remove
 #'   autapses (defaults to TRUE)
 #' @param chunksize (expert use) number of query neurons to send per chunk to

--- a/R/vcache.R
+++ b/R/vcache.R
@@ -27,5 +27,15 @@ vcache_mset <- function(vc, keys, values) {
   if(!isTRUE(length(keys)==length(values)))
      stop("mismatch between length of keys and values!")
   names(values)=keys
-  vc$mset(.list=as.list(values))
+  vc$mset(.list=as_list_chunked(values))
+}
+
+# work around a bug in bit64::as.list.integer64()
+# (see https://github.com/r-lib/bit64/pull/346)
+as_list_chunked <- function(x, chunk=1e4L) {
+  if(length(x)<=chunk) return(as.list(x))
+  idx <- nat.utils::make_chunks(seq_along(x), chunksize=chunk)
+  l <- unlist(lapply(idx, function(i) as.list(x[i])), recursive=FALSE)
+  names(l) <- names(x)
+  l
 }

--- a/man/flywire_partners.Rd
+++ b/man/flywire_partners.Rd
@@ -92,6 +92,9 @@ must be located. Can be a \code{\link[rgl]{mesh3d}} object, or any object which
 \code{\link[nat]{boundingbox}} objects. See \code{\link[nat]{pointsinside}} for
 details.}
 
+\item{invert_surf}{When \code{TRUE}, select partners whose presynaptic
+position lies \emph{outside} the \code{surf} ROI rather than inside.}
+
 \item{version}{Integer materialisation version. The special value of
 \code{'latest'} means the most recent materialisation according to CAVE.}
 

--- a/tests/testthat/test-vcache.R
+++ b/tests/testthat/test-vcache.R
@@ -6,3 +6,15 @@ test_that("multiplication works", {
   expect_equal(vcache_mget(v64, '1'), bit64::as.integer64(1L))
   expect_equal(vcache_mget(v64, '-1'), bit64::as.integer64(0L))
 })
+
+test_that("vcache_mset handles large integer64 vectors", {
+  skip_if_not_installed('fastmap')
+  # as.list.integer64() overflows the protection stack past ~R_PPStackSize
+  # (bit64 <=4.8.2, r-lib/bit64#346); vcache_mset chunks to avoid this.
+  n <- 60000L
+  v64 <- vcache64('rhubarb-big-test')
+  keys <- as.character(seq_len(n))
+  vals <- bit64::as.integer64(seq_len(n))
+  expect_silent(vcache_mset(v64, keys, vals))
+  expect_equal(vcache_mget(v64, keys), vals)
+})


### PR DESCRIPTION
bit64::as.list.integer64() PROTECTs once per element in a C loop (r-lib/bit64#346), overflowing R's protection stack for integer64 vectors longer than ~R_PPStackSize. This surfaced as a protection stack overflow when flywire_updateids() cached a large batch of supervoxel->root id mappings.

vcache_mset() now converts via as_list_chunked(), which splits into 10k blocks so each as.list() stays under the limit regardless of the installed bit64 version.