### PR TITLE
cam_meta: translate stale explicit ids to requested version/timestamp

### DIFF
--- a/R/flytable-cam.R
+++ b/R/flytable-cam.R
@@ -46,11 +46,17 @@
 #'   further work is needed. For explicit root \code{ids} the join is by
 #'   \code{root_id}, so ids that are stale relative to the requested timepoint
 #'   would silently fail to match. \code{translate_ids} guards against this by
-#'   first bringing the supplied ids forward with \code{\link{flywire_latestid}}
-#'   (which is cheap for ids that are already current). The default (\code{NA})
-#'   enables it whenever a \code{version}/\code{timestamp} is supplied; with
-#'   neither, nothing is translated since the table is simply at the state of
-#'   its last update.
+#'   bringing only the unmatched ids forward with \code{\link{flywire_latestid}}
+#'   (ids already present in the mapped table need no work, and
+#'   \code{flywire_latestid} only does a supervoxel lookup for genuinely
+#'   outdated ids). The default (\code{NA}) enables it whenever a
+#'   \code{version}/\code{timestamp} is supplied; with neither, nothing is
+#'   translated since the table is simply at the state of its last update.
+#'
+#'   If \code{translate_ids} is forced \code{TRUE} with no
+#'   \code{version}/\code{timestamp}, ids are aligned to the table's own sync
+#'   time (its \code{mtime} attribute) rather than live 'now', so both sides
+#'   share a clock.
 #'
 #' @returns A data frame with appropriate rows based on the \code{ids} argument.
 #'
@@ -81,6 +87,8 @@ cam_meta <- function(ids=NULL, ignore.case = F, fixed = F, table='aedes_main',
     ids=paste0("type:", ids)
 
   aedes_main = fafbseg::flytable_cached_table(table = table, base=base, ...)
+  # capture before any dplyr verb below strips this attribute
+  table_mtime = attr(aedes_main, 'mtime')
   fields=colnames(aedes_main)
   if("status" %in% fields)
     aedes_main = dplyr::filter(aedes_main,
@@ -106,11 +114,26 @@ cam_meta <- function(ids=NULL, ignore.case = F, fixed = F, table='aedes_main',
     ids <- fafbseg::flywire_ids(ids, integer64 = FALSE, unique = TRUE)
     if(is.na(translate_ids))
       translate_ids <- !is.null(version) || !is.null(timestamp)
-    if(isTRUE(translate_ids))
-      ids <- fafbseg::flywire_latestid(ids, version = version, timestamp = timestamp)
-    df=data.frame(root_id=ids)
+    # Map the table to the requested timepoint first, so the membership test
+    # below is against the root_ids the join will actually see.
     if(!is.null(version) || !is.null(timestamp))
       aedes_main$root_id=fafbseg::flywire_updateids(aedes_main$root_id, svids = aedes_main$supervoxel_id, version = version, timestamp = timestamp)
+    if(isTRUE(translate_ids)) {
+      tts <- timestamp
+      if(is.null(version) && is.null(timestamp) && !is.null(table_mtime))
+        # No timepoint pins the table, so align ids to its own sync time (mtime)
+        # rather than live 'now', which the un-mapped table lags.
+        tts <- flytable_parse_date(table_mtime, format = 'timestamp')
+      # Only ids absent from the (mapped) table can need translating: a stale id
+      # can never equal a mapped-table root. Translate just those -- and
+      # flywire_latestid only does the supervoxel lookup for genuinely outdated
+      # ones, so present-and-current ids cost nothing.
+      needs <- !ids %in% aedes_main$root_id
+      if(any(needs))
+        ids[needs] <- fafbseg::flywire_latestid(ids[needs], version = version,
+                                                timestamp = tts)
+    }
+    df=data.frame(root_id=ids)
     df=dplyr::left_join(df, aedes_main, by='root_id')
   }
 

--- a/R/flytable-cam.R
+++ b/R/flytable-cam.R
@@ -16,6 +16,10 @@
 #'   There is no special logic in choosing which rows to drop, but the dropped
 #'   rows are retained as an attribute on the table with a warning so that you
 #'   can inspect.
+#' @param translate_ids Whether to bring explicitly supplied \code{ids} forward
+#'   to the requested \code{version}/\code{timestamp} before matching. \code{NA}
+#'   (the default) turns this on automatically when a \code{version} or
+#'   \code{timestamp} is given (see details).
 #' @param token Optional API token. When supplied, the \code{FLYTABLE_TOKEN}
 #'   environment variable is temporarily set to this value for the duration of
 #'   the call (and restored on exit) so you can authenticate against an
@@ -36,6 +40,18 @@
 #'   Note that rows with status `duplicate` or `bad_nucleus` are dropped even
 #'   before the `unique` argument is processed.
 #'
+#'   When \code{version} or \code{timestamp} are specified the table's root ids
+#'   are brought to that timepoint via the \code{supervoxel_id} column. For a
+#'   query string the match then happens against that mapped table, so no
+#'   further work is needed. For explicit root \code{ids} the join is by
+#'   \code{root_id}, so ids that are stale relative to the requested timepoint
+#'   would silently fail to match. \code{translate_ids} guards against this by
+#'   first bringing the supplied ids forward with \code{\link{flywire_latestid}}
+#'   (which is cheap for ids that are already current). The default (\code{NA})
+#'   enables it whenever a \code{version}/\code{timestamp} is supplied; with
+#'   neither, nothing is translated since the table is simply at the state of
+#'   its last update.
+#'
 #' @returns A data frame with appropriate rows based on the \code{ids} argument.
 #'
 #' @export
@@ -54,7 +70,7 @@
 cam_meta <- function(ids=NULL, ignore.case = F, fixed = F, table='aedes_main',
                      base=NULL,
                      version=NULL, timestamp=NULL, unique=FALSE,
-                     token=NULL, ...) {
+                     translate_ids=NA, token=NULL, ...) {
 
   if (!is.null(token))
     withr::local_envvar(FLYTABLE_TOKEN = token)
@@ -88,6 +104,10 @@ cam_meta <- function(ids=NULL, ignore.case = F, fixed = F, table='aedes_main',
     df=aedes_main
   else {
     ids <- fafbseg::flywire_ids(ids, integer64 = FALSE, unique = TRUE)
+    if(is.na(translate_ids))
+      translate_ids <- !is.null(version) || !is.null(timestamp)
+    if(isTRUE(translate_ids))
+      ids <- fafbseg::flywire_latestid(ids, version = version, timestamp = timestamp)
     df=data.frame(root_id=ids)
     if(!is.null(version) || !is.null(timestamp))
       aedes_main$root_id=fafbseg::flywire_updateids(aedes_main$root_id, svids = aedes_main$supervoxel_id, version = version, timestamp = timestamp)

--- a/man/cam_meta.Rd
+++ b/man/cam_meta.Rd
@@ -13,6 +13,7 @@ cam_meta(
   version = NULL,
   timestamp = NULL,
   unique = FALSE,
+  translate_ids = NA,
   token = NULL,
   ...
 )
@@ -40,6 +41,11 @@ UTC. The special value of \code{'now'} means the current time in UTC.}
 There is no special logic in choosing which rows to drop, but the dropped
 rows are retained as an attribute on the table with a warning so that you
 can inspect.}
+
+\item{translate_ids}{Whether to bring explicitly supplied \code{ids} forward
+to the requested \code{version}/\code{timestamp} before matching. \code{NA}
+(the default) turns this on automatically when a \code{version} or
+\code{timestamp} is given (see details).}
 
 \item{token}{Optional API token. When supplied, the \code{FLYTABLE_TOKEN}
 environment variable is temporarily set to this value for the duration of
@@ -71,6 +77,18 @@ This function now uses \code{\link{flytable_cached_table}} for
 
   Note that rows with status `duplicate` or `bad_nucleus` are dropped even
   before the `unique` argument is processed.
+
+  When \code{version} or \code{timestamp} are specified the table's root ids
+  are brought to that timepoint via the \code{supervoxel_id} column. For a
+  query string the match then happens against that mapped table, so no
+  further work is needed. For explicit root \code{ids} the join is by
+  \code{root_id}, so ids that are stale relative to the requested timepoint
+  would silently fail to match. \code{translate_ids} guards against this by
+  first bringing the supplied ids forward with \code{\link{flywire_latestid}}
+  (which is cheap for ids that are already current). The default (\code{NA})
+  enables it whenever a \code{version}/\code{timestamp} is supplied; with
+  neither, nothing is translated since the table is simply at the state of
+  its last update.
 }
 \examples{
 # implies type

--- a/man/cam_meta.Rd
+++ b/man/cam_meta.Rd
@@ -84,11 +84,17 @@ This function now uses \code{\link{flytable_cached_table}} for
   further work is needed. For explicit root \code{ids} the join is by
   \code{root_id}, so ids that are stale relative to the requested timepoint
   would silently fail to match. \code{translate_ids} guards against this by
-  first bringing the supplied ids forward with \code{\link{flywire_latestid}}
-  (which is cheap for ids that are already current). The default (\code{NA})
-  enables it whenever a \code{version}/\code{timestamp} is supplied; with
-  neither, nothing is translated since the table is simply at the state of
-  its last update.
+  bringing only the unmatched ids forward with \code{\link{flywire_latestid}}
+  (ids already present in the mapped table need no work, and
+  \code{flywire_latestid} only does a supervoxel lookup for genuinely
+  outdated ids). The default (\code{NA}) enables it whenever a
+  \code{version}/\code{timestamp} is supplied; with neither, nothing is
+  translated since the table is simply at the state of its last update.
+
+  If \code{translate_ids} is forced \code{TRUE} with no
+  \code{version}/\code{timestamp}, ids are aligned to the table's own sync
+  time (its \code{mtime} attribute) rather than live 'now', so both sides
+  share a clock.
 }
 \examples{
 # implies type

--- a/tests/testthat/test-flytable-cam.R
+++ b/tests/testthat/test-flytable-cam.R
@@ -8,5 +8,14 @@ test_that("multiplication works", {
   skip_if(inherits(fat, 'try-error'),
           "skipping flytable tests as having trouble listing all tables!")
 
-  with_segmentation('flywire31', expect_true(nrow(cam_meta('/cell_class:MBON', table = 'info', base='main'))>50 ))
+  expect_s3_class(mbons <- with_segmentation('flywire31', cam_meta('/cell_class:MBON', table = 'info', base='main')), 'data.frame')
+  expect_true(nrow(mbons)>50)
+  # now pick out one row where MBON was edited after 783 materialisation
+  mbons.updated <- mbons[mbons$root_id!=mbons$root_783,]
+  mbons.updated.1 <- mbons.updated[1,]
+  # ... and check we can pull that up with the stale id
+  expect_equal(with_segmentation('flywire31',
+    cam_meta(mbons.updated.1$root_783, table = 'info', base='main',
+             translate_ids = TRUE))$supervoxel_id,
+    mbons.updated.1$supervoxel_id)
 })

--- a/tests/testthat/test-flytable-cam.R
+++ b/tests/testthat/test-flytable-cam.R
@@ -18,4 +18,21 @@ test_that("multiplication works", {
     cam_meta(mbons.updated.1$root_783, table = 'info', base='main',
              translate_ids = TRUE))$supervoxel_id,
     mbons.updated.1$supervoxel_id)
+
+  # negative control: without translation the stale id does not match
+  expect_true(is.na(with_segmentation('flywire31',
+    cam_meta(mbons.updated.1$root_783, table = 'info', base='main',
+             translate_ids = FALSE))$supervoxel_id))
+
+  # the NA default auto-enables translation once a timestamp is supplied
+  expect_equal(with_segmentation('flywire31',
+    cam_meta(mbons.updated.1$root_783, table = 'info', base='main',
+             timestamp = 'now'))$supervoxel_id,
+    mbons.updated.1$supervoxel_id)
+
+  # translate_ids must not perturb the query path
+  expect_equal(with_segmentation('flywire31',
+    sort(cam_meta('/cell_class:MBON', table = 'info', base='main',
+                  translate_ids = TRUE)$root_id)),
+    sort(mbons$root_id))
 })


### PR DESCRIPTION
## Summary

Adds a `translate_ids` argument to `cam_meta()`. When explicit root ids are supplied together with a `version`/`timestamp`, ids that are **stale** relative to that timepoint previously failed to match the timestamp-mapped table and silently dropped out of the result. `translate_ids` brings the supplied ids forward with `flywire_latestid()` before the join.

- Applies only in the explicit-ids branch (query strings and `ids=NULL` are untouched).
- `flywire_latestid()` short-circuits ids that are already current via `flywire_islatest()`, so translating the whole vector only pays the supervoxel lookup for genuinely outdated ids.
- Defaults to `NA` → `TRUE` whenever a `version`/`timestamp` is given; with neither, nothing is translated (the table is simply at the state of its last update).

## Test

`test-flytable-cam.R` picks an `info`/`main` MBON edited since the 783 release (`root_id != root_783`) and confirms its `root_783` (a real historic id) is pulled up to the correct `supervoxel_id` with `translate_ids = TRUE`. Live, skip-guarded on login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)