### PR TITLE
Fix silent row truncation from SeaTable per-call row caps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: fafbseg
 Title: Support Functions for Analysis of FAFB EM Segmentation
-Version: 0.15.10
+Version: 0.15.11
 Authors@R: 
     c(person(given = "Gregory",
              family = "Jefferis",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,31 @@
+# fafbseg 0.15.11
+
+Bug fixes:
+
+* Fix silent row truncation for flytable tables larger than the server's SQL
+  query row cap. Seatable's SQL endpoint silently caps a single call at a
+  server-specific maximum (documented default 10,000 rows for SELECT queries,
+  <https://api.seatable.com/reference/limits>; self-hosted servers may allow
+  more) with no error or truncation signal. `flytable_query()` now paginates
+  transparently through `LIMIT`/`OFFSET` by default (new `paginate` argument)
+  so it returns the full result rather than a truncated one; small results and
+  queries that pin their own `limit`/`offset` still cost a single request. This
+  was hit in practice on the cloud.seatable.io-hosted CRANTb_meta table
+  (12,652 rows), though not on our self-hosted Cambridge flytable server (which
+  raises the caps to 100,000). There is no API to discover a given server's
+  configured cap, so pagination self-adapts to whatever it turns out to be.
+* `flytable_full_fetch()` (used by `flytable_cached_table()` and therefore
+  `cam_meta()`) now pages through the table against its known row count, so a
+  cold fetch of a table larger than the server's per-call cap is no longer
+  silently truncated.
+* Fix a related pagination bug in `flytable_list_rows()`: its page-fetch loop
+  stopped as soon as a page came back with fewer rows than requested, on the
+  assumption that meant the end of the table. In fact the list-rows endpoint
+  also enforces its own per-call page-size cap (documented default 1000 rows,
+  also server-configurable) regardless of what is requested, so a short page
+  does not mean the table is exhausted. The loop now continues until it
+  receives a genuinely empty page.
+
 # fafbseg 0.15.10
 
 New features and enhancements:

--- a/R/flytable-cache.R
+++ b/R/flytable-cache.R
@@ -171,22 +171,53 @@ flytable_cached_table <- function(table, expiry = 300, refresh = FALSE,
 
 
 #' Full fetch of a flytable table
+#'
+#' @details Pages through the table with \code{\link{flytable_query}} using
+#'   \code{LIMIT}/\code{OFFSET}. The SQL query endpoint silently caps a single
+#'   call at some maximum row count (SeaTable's documented default is 10,000
+#'   rows for SELECT queries, \url{https://api.seatable.com/reference/limits},
+#'   though self-hosted servers may configure a higher cap) with no truncation
+#'   warning, so a single \code{select *} would corrupt the cache for any
+#'   table larger than the server's limit. There is no API to discover a
+#'   server's configured cap, so we ask for the known row count up front and
+#'   keep fetching pages until we have them all (the server caps each page as
+#'   needed); a single page suffices when the table fits under the cap.
 #' @keywords internal
 #' @noRd
 flytable_full_fetch <- function(table, base = NULL, collapse_lists = TRUE,
                                 limit = 100000L) {
-  mtime <- tryCatch(
-    flytable_now(table),
+  meta <- tryCatch(
+    flytable_sync_metadata(table),
     error = function(e) {
       stop("Unable to connect to flytable: ", conditionMessage(e))
     }
   )
+  mtime <- meta$now
+  # How many rows we ultimately want (respecting the caller's `limit`).
+  want <- min(meta$nrow, limit)
+  if (want < 1) return(NULL)
 
-  res <- flytable_query(paste('select * from', table), base = base,
-                        collapse_lists = collapse_lists, limit = limit)
+  pages <- list()
+  offset <- 0L
+  repeat {
+    if (offset >= want) break
+    page <- flytable_query(
+      paste0('select * from ', table, ' limit ', want - offset,
+             ' offset ', offset),
+      base = base, collapse_lists = collapse_lists)
+    # An empty page is a safety backstop (e.g. rows deleted since the count),
+    # otherwise we advance by however many rows the server actually returned
+    # -- which self-adapts to whatever per-call cap it enforces.
+    if (is.null(page) || nrow(page) == 0) break
+    pages[[length(pages) + 1]] <- page
+    offset <- offset + nrow(page)
+  }
 
-  if (is.null(res) || !is.data.frame(res)) {
-    return(NULL)
+  if (length(pages) == 0) return(NULL)
+  res <- if (length(pages) == 1) pages[[1]] else {
+    tt <- try(do.call(rbind, pages), silent = TRUE)
+    if (inherits(tt, 'try-error')) tt <- dplyr::bind_rows(pages)
+    tt
   }
 
   attr(res, 'mtime') <- mtime

--- a/R/flytable-cache.R
+++ b/R/flytable-cache.R
@@ -182,10 +182,15 @@ flytable_cached_table <- function(table, expiry = 300, refresh = FALSE,
 #'   server's configured cap, so we ask for the known row count up front and
 #'   keep fetching pages until we have them all (the server caps each page as
 #'   needed); a single page suffices when the table fits under the cap.
+#' @param chunksize Optional maximum rows to request per page. \code{NULL}
+#'   (the default) requests all outstanding rows each call and lets the server
+#'   cap them; a small value forces multiple pages, which is how this paging
+#'   loop is exercised against a real server whose own cap is too high to reach
+#'   with a modest table.
 #' @keywords internal
 #' @noRd
 flytable_full_fetch <- function(table, base = NULL, collapse_lists = TRUE,
-                                limit = 100000L) {
+                                limit = 100000L, chunksize = NULL) {
   meta <- tryCatch(
     flytable_sync_metadata(table),
     error = function(e) {
@@ -201,8 +206,10 @@ flytable_full_fetch <- function(table, base = NULL, collapse_lists = TRUE,
   offset <- 0L
   repeat {
     if (offset >= want) break
+    thispage <- want - offset
+    if (!is.null(chunksize)) thispage <- min(thispage, as.integer(chunksize))
     page <- flytable_query(
-      paste0('select * from ', table, ' limit ', want - offset,
+      paste0('select * from ', table, ' limit ', thispage,
              ' offset ', offset),
       base = base, collapse_lists = collapse_lists)
     # An empty page is a safety backstop (e.g. rows deleted since the count),

--- a/R/flytable.R
+++ b/R/flytable.R
@@ -231,7 +231,14 @@ flytable_list_rows <- function(table, base=NULL, view_name = NULL, order_by = NU
   if(is.null(chunksize))
     chunksize=pmin(floor(1e6/ncols),50000)
   res <- if(limit>chunksize) {
-    # we can only get 50k rows at a time
+    # The list-rows API enforces its own per-request page-size cap, regardless
+    # of the `limit` we send -- seatable's documented default is 1000
+    # rows/request (https://api.seatable.com/reference/limits), but this is
+    # server-configurable (our Cambridge server allows up to 100,000) and
+    # there's no API to discover it. So a page coming back shorter than
+    # requested does NOT signal the end of the table: the only reliable
+    # end-of-table signal is an empty (0-row) page. Keep requesting pages
+    # (which the server silently caps as needed) until one comes back empty.
     start=0L
     resl=list()
     while(TRUE) {
@@ -243,11 +250,12 @@ flytable_list_rows <- function(table, base=NULL, view_name = NULL, order_by = NU
                                    limit=rowstofetch)
       if(nrow(tres)==0) break
       resl[[length(resl)+1]]=tres
-      if(nrow(tres)<rowstofetch) break
       start=start+nrow(tres)
     }
     if(length(resl)>1 && python)
-      stop("Unable to return more than 50,000 rows when python=T!")
+      stop("Unable to return chunked results (multiple page requests were ",
+           "needed) when python=TRUE; use python=FALSE, or narrow the ",
+           "result with a query/view/limit.")
     # bind lists
     resl=lapply(resl, reticulate::py_to_r)
     allcols=unique(sapply(resl, colnames))
@@ -301,9 +309,20 @@ flytable_list_rows_chunk <- function(base, table, view_name, order_by, desc, sta
 #' @param sql A SQL query string. See examples and
 #'   \href{https://seatable.github.io/seatable-scripts/python/query/}{seatable
 #'   docs}.
-#' @param limit An optional limit, which only applies if you do not specify a
-#'   limit directly in the \code{sql} query. By default seatable limits SQL
-#'   queries to 100 rows. We increase the limit to 100000 rows by default.
+#' @param limit An optional limit on the total number of rows returned, which
+#'   only applies if you do not specify a limit directly in the \code{sql}
+#'   query. By default seatable limits SQL queries to 100 rows. We increase the
+#'   limit to 100000 rows by default. See \code{paginate} for how this interacts
+#'   with the server's per-call row cap.
+#' @param paginate Whether to transparently page through large results with
+#'   \code{LIMIT}/\code{OFFSET} (default \code{TRUE}). Seatable's SQL endpoint
+#'   silently caps a single call at a server-specific maximum (documented
+#'   default 10,000 rows for SELECT queries, \url{https://api.seatable.com/reference/limits};
+#'   self-hosted servers may allow more) with no truncation warning, so without
+#'   pagination a query matching more rows than the cap would silently lose
+#'   rows. Pagination is skipped automatically when you supply your own
+#'   \code{limit}/\code{offset} in the \code{sql}, when \code{python=TRUE}, or
+#'   when the first page already returns fewer rows than the guaranteed cap.
 #' @param collapse_lists Whether to collapse any list multi-select columns into
 #'   simple strings. The default value of \code{collapse_lists=TRUE} will comma
 #'   separate them.
@@ -324,7 +343,7 @@ flytable_list_rows_chunk <- function(base, table, view_name, order_by, desc, sta
 #' flytable_query(paste("SELECT root_id, supervoxel_id FROM info limit 5"))
 #' }
 flytable_query <- function(sql, limit=100000L, base=NULL, python=FALSE,
-                           convert=TRUE, collapse_lists=TRUE) {
+                           convert=TRUE, collapse_lists=TRUE, paginate=TRUE) {
   checkmate::assert_character(sql, len=1, pattern = 'select', ignore.case = T)
   # parse SQL to find a table
   res=stringr::str_match(sql,
@@ -339,33 +358,85 @@ flytable_query <- function(sql, limit=100000L, base=NULL, python=FALSE,
            " from your SQL query but couldn't connect to a base with this table!")
   } else if(is.character(base))
     base=flytable_base(base_name = base)
-  if(!isTRUE(grepl("\\s+limit\\s+\\d+", sql)) && !isFALSE(limit)) {
-    if(!is.finite(limit)) limit=.Machine$integer.max
-    sql=paste(sql, "LIMIT", limit)
-  }
-  pyout <- reticulate::py_capture_output(
-    ll <- try(reticulate::py_call(base$query, sql, convert=convert), silent = T)
-    )
-  if(inherits(ll, 'try-error')) {
-    warning(paste('No rows returned by flytable', pyout, collapse = '\n'))
-    return(NULL)
-  }
-  pd=reticulate::import('pandas')
-  reticulate::py_capture_output(pdd <- reticulate::py_call(pd$DataFrame, ll))
 
-  if(python) pdd else {
-    colinfo=flytable_columns(table, base)
+  has_own_limit <- isTRUE(grepl("\\s+limit\\s+\\d+", sql, ignore.case = TRUE))
+  if(!is.finite(limit)) limit <- .Machine$integer.max
+
+  # Single call to the seatable query endpoint plus our usual post-processing.
+  # colinfo is fetched once and captured so paged calls don't refetch it.
+  colinfo <- if(python) NULL else flytable_columns(table, base)
+  run_one <- function(sqltext) {
+    pyout <- reticulate::py_capture_output(
+      ll <- try(reticulate::py_call(base$query, sqltext, convert=convert), silent = T)
+    )
+    if(inherits(ll, 'try-error')) {
+      warning(paste('No rows returned by flytable', pyout, collapse = '\n'))
+      return(NULL)
+    }
+    pd=reticulate::import('pandas')
+    reticulate::py_capture_output(pdd <- reticulate::py_call(pd$DataFrame, ll))
+    if(python) return(pdd)
     df=flytable2df(pandas2df(pdd, use_arrow = F),
                    tidf = colinfo, collapse=collapse_lists)
-    fields=sql2fields(sql)
-    if(length(fields)==1 && fields=="*") {
+    fields=sql2fields(sqltext)
+    if(length(fields)==1 && fields=="*")
       toorder=intersect(colinfo$name, colnames(df))
-    } else {
-      toorder=intersect(sql2fields(sql), colnames(df))
-    }
+    else
+      toorder=intersect(fields, colnames(df))
     rest=setdiff(colnames(df),toorder)
     df[c(toorder, rest)]
   }
+
+  # Pagination only makes sense for a plain SELECT where we control the row
+  # window: skip it if the caller pinned their own limit/offset, asked for the
+  # raw python object, or disabled it.
+  do_paginate <- isTRUE(paginate) && !python && !has_own_limit && !isFALSE(limit)
+  if(!do_paginate) {
+    sqltext <- if(!has_own_limit && !isFALSE(limit)) paste(sql, "LIMIT", limit) else sql
+    return(run_one(sqltext))
+  }
+
+  # Every seatable server guarantees an SQL SELECT cap of at least this many
+  # rows, so a first page returning fewer than this cannot have been truncated
+  # -- letting the common small-result case complete in a single request.
+  guaranteed_cap <- 10000L
+  page1 <- run_one(paste(sql, "LIMIT", limit, "OFFSET 0"))
+  if(is.null(page1)) return(NULL)
+  np1 <- nrow(page1)
+  if(np1 >= limit || np1 < guaranteed_cap)
+    return(page1)
+
+  # np1 rows came back (>= guaranteed_cap and < our limit): the server may have
+  # capped at exactly np1, or the result may genuinely be np1 long. Probe one
+  # row beyond to disambiguate without assuming the (unknowable) server cap.
+  probe <- run_one(paste(sql, "LIMIT 1 OFFSET", np1))
+  if(is.null(probe) || nrow(probe)==0)
+    return(page1)
+
+  # Confirmed truncation: np1 is the server's per-call cap. Keep paging in
+  # cap-sized windows until a short/empty page marks the end of the result
+  # (a page shorter than the requested window can now only mean end-of-data,
+  # since we never request more than the cap).
+  cap <- np1
+  pages <- list(page1)
+  offset <- np1
+  repeat {
+    remaining <- limit - offset
+    if(remaining < 1) break
+    ps <- min(cap, remaining)
+    page <- run_one(paste(sql, "LIMIT", ps, "OFFSET", offset))
+    if(is.null(page) || nrow(page)==0) break
+    pages[[length(pages)+1]] <- page
+    offset <- offset + nrow(page)
+    if(nrow(page) < ps) break
+  }
+  out <- if(length(pages)==1) pages[[1]] else {
+    tt <- try(do.call(rbind, pages), silent = TRUE)
+    if(inherits(tt, 'try-error')) tt <- dplyr::bind_rows(pages)
+    tt
+  }
+  if(nrow(out) > limit) out <- out[seq_len(limit), , drop=FALSE]
+  out
 }
 
 sql2fields <- function(sql) {

--- a/R/flytable.R
+++ b/R/flytable.R
@@ -196,9 +196,12 @@ flytable_base <- function(table=NULL, base_name=NULL,
 #' @param start Optional starting row
 #' @param limit Maximum number of rows to return (the default \code{Inf} implies
 #'   all rows)
-#' @param chunksize Optional The maximum number of rows to request in one web
-#'   request. For advanced use only as the default value of \code{NULL} will
-#'   fetch as many as possible.
+#' @param chunksize Optional maximum number of rows to request per web request.
+#'   For advanced use only; the default \code{NULL} fetches as many rows per
+#'   call as the server allows. For \code{flytable_query} a non-\code{NULL}
+#'   value forces \code{LIMIT}/\code{OFFSET} pagination in windows of this size
+#'   (mainly useful for exercising the paging path against a server whose own
+#'   row cap is too high to reach with a modest table).
 #' @param python Whether to return a Python pandas \code{DataFrame}. The default
 #'   of \code{FALSE} returns an R \code{data.frame}
 #'
@@ -343,7 +346,8 @@ flytable_list_rows_chunk <- function(base, table, view_name, order_by, desc, sta
 #' flytable_query(paste("SELECT root_id, supervoxel_id FROM info limit 5"))
 #' }
 flytable_query <- function(sql, limit=100000L, base=NULL, python=FALSE,
-                           convert=TRUE, collapse_lists=TRUE, paginate=TRUE) {
+                           convert=TRUE, collapse_lists=TRUE, paginate=TRUE,
+                           chunksize=NULL) {
   checkmate::assert_character(sql, len=1, pattern = 'select', ignore.case = T)
   # parse SQL to find a table
   res=stringr::str_match(sql,
@@ -396,30 +400,47 @@ flytable_query <- function(sql, limit=100000L, base=NULL, python=FALSE,
     return(run_one(sqltext))
   }
 
-  # Every seatable server guarantees an SQL SELECT cap of at least this many
-  # rows, so a first page returning fewer than this cannot have been truncated
-  # -- letting the common small-result case complete in a single request.
-  guaranteed_cap <- 10000L
-  page1 <- run_one(paste(sql, "LIMIT", limit, "OFFSET 0"))
-  if(is.null(page1)) return(NULL)
-  np1 <- nrow(page1)
-  if(np1 >= limit || np1 < guaranteed_cap)
-    return(page1)
+  if(is.null(chunksize)) {
+    # Auto-detect path (production default). Fetch as much as the server will
+    # give in one call, then only page further if that first page looks
+    # truncated. Every seatable server guarantees an SQL SELECT cap of at least
+    # this many rows, so a first page returning fewer than this cannot have
+    # been truncated -- letting the common small-result case complete in a
+    # single request.
+    guaranteed_cap <- 10000L
+    page1 <- run_one(paste(sql, "LIMIT", limit, "OFFSET 0"))
+    if(is.null(page1)) return(NULL)
+    np1 <- nrow(page1)
+    if(np1 >= limit || np1 < guaranteed_cap)
+      return(page1)
 
-  # np1 rows came back (>= guaranteed_cap and < our limit): the server may have
-  # capped at exactly np1, or the result may genuinely be np1 long. Probe one
-  # row beyond to disambiguate without assuming the (unknowable) server cap.
-  probe <- run_one(paste(sql, "LIMIT 1 OFFSET", np1))
-  if(is.null(probe) || nrow(probe)==0)
-    return(page1)
+    # np1 rows came back (>= guaranteed_cap and < our limit): the server may
+    # have capped at exactly np1, or the result may genuinely be np1 long.
+    # Probe one row beyond to disambiguate without assuming the (unknowable)
+    # server cap.
+    probe <- run_one(paste(sql, "LIMIT 1 OFFSET", np1))
+    if(is.null(probe) || nrow(probe)==0)
+      return(page1)
 
-  # Confirmed truncation: np1 is the server's per-call cap. Keep paging in
-  # cap-sized windows until a short/empty page marks the end of the result
-  # (a page shorter than the requested window can now only mean end-of-data,
-  # since we never request more than the cap).
-  cap <- np1
-  pages <- list(page1)
-  offset <- np1
+    # Confirmed truncation: np1 is the server's per-call cap.
+    cap <- np1
+    pages <- list(page1)
+    offset <- np1
+  } else {
+    # Caller forced a page window (advanced use, and how the paging path is
+    # exercised in tests against a real server whose own cap is too high to hit
+    # with a modest table): page from the start in chunksize-sized windows.
+    cap <- min(as.integer(chunksize), limit)
+    pages <- list()
+    offset <- 0L
+  }
+
+  # Shared paging loop: request cap-sized windows until a short or empty page
+  # marks the end of the result. A page shorter than the requested window can
+  # only mean end-of-data, since we never request more than `cap`. This relies
+  # on the server returning rows in a stable order across calls -- seatable
+  # appears to page in row-creation order; that is not documented but is
+  # assumed here (we deliberately impose no ORDER BY).
   repeat {
     remaining <- limit - offset
     if(remaining < 1) break
@@ -430,6 +451,7 @@ flytable_query <- function(sql, limit=100000L, base=NULL, python=FALSE,
     offset <- offset + nrow(page)
     if(nrow(page) < ps) break
   }
+  if(length(pages)==0) return(NULL)
   out <- if(length(pages)==1) pages[[1]] else {
     tt <- try(do.call(rbind, pages), silent = TRUE)
     if(inherits(tt, 'try-error')) tt <- dplyr::bind_rows(pages)

--- a/man/flytable-queries.Rd
+++ b/man/flytable-queries.Rd
@@ -26,7 +26,8 @@ flytable_query(
   python = FALSE,
   convert = TRUE,
   collapse_lists = TRUE,
-  paginate = TRUE
+  paginate = TRUE,
+  chunksize = NULL
 )
 }
 \arguments{
@@ -57,9 +58,12 @@ separate them.}
 \item{python}{Whether to return a Python pandas \code{DataFrame}. The default
 of \code{FALSE} returns an R \code{data.frame}}
 
-\item{chunksize}{Optional The maximum number of rows to request in one web
-request. For advanced use only as the default value of \code{NULL} will
-fetch as many as possible.}
+\item{chunksize}{Optional maximum number of rows to request per web request.
+For advanced use only; the default \code{NULL} fetches as many rows per
+call as the server allows. For \code{flytable_query} a non-\code{NULL}
+value forces \code{LIMIT}/\code{OFFSET} pagination in windows of this size
+(mainly useful for exercising the paging path against a server whose own
+row cap is too high to reach with a modest table).}
 
 \item{sql}{A SQL query string. See examples and
 \href{https://seatable.github.io/seatable-scripts/python/query/}{seatable

--- a/man/flytable-queries.Rd
+++ b/man/flytable-queries.Rd
@@ -25,7 +25,8 @@ flytable_query(
   base = NULL,
   python = FALSE,
   convert = TRUE,
-  collapse_lists = TRUE
+  collapse_lists = TRUE,
+  paginate = TRUE
 )
 }
 \arguments{
@@ -43,9 +44,11 @@ ascending order)}
 
 \item{start}{Optional starting row}
 
-\item{limit}{An optional limit, which only applies if you do not specify a
-limit directly in the \code{sql} query. By default seatable limits SQL
-queries to 100 rows. We increase the limit to 100000 rows by default.}
+\item{limit}{An optional limit on the total number of rows returned, which
+only applies if you do not specify a limit directly in the \code{sql}
+query. By default seatable limits SQL queries to 100 rows. We increase the
+limit to 100000 rows by default. See \code{paginate} for how this interacts
+with the server's per-call row cap.}
 
 \item{collapse_lists}{Whether to collapse any list multi-select columns into
 simple strings. The default value of \code{collapse_lists=TRUE} will comma
@@ -65,6 +68,16 @@ docs}.}
 \item{convert}{Expert use only: Whether or not to allow the Python seatable
 module to process raw output from the database. This is is principally for
 debugging purposes. NB this imposes a requirement of seatable_api >=2.4.0.}
+
+\item{paginate}{Whether to transparently page through large results with
+\code{LIMIT}/\code{OFFSET} (default \code{TRUE}). Seatable's SQL endpoint
+silently caps a single call at a server-specific maximum (documented
+default 10,000 rows for SELECT queries, \url{https://api.seatable.com/reference/limits};
+self-hosted servers may allow more) with no truncation warning, so without
+pagination a query matching more rows than the cap would silently lose
+rows. Pagination is skipped automatically when you supply your own
+\code{limit}/\code{offset} in the \code{sql}, when \code{python=TRUE}, or
+when the first page already returns fewer rows than the guaranteed cap.}
 }
 \value{
 An R \code{data.frame} or Pandas \code{DataFrame} depending on the

--- a/man/flytable_cached_table.Rd
+++ b/man/flytable_cached_table.Rd
@@ -30,9 +30,11 @@ multi-select columns into comma-separated strings. Passed to
 \item{base}{Optional base name if table name is ambiguous (exists in multiple
 bases).}
 
-\item{limit}{An optional limit, which only applies if you do not specify a
-limit directly in the \code{sql} query. By default seatable limits SQL
-queries to 100 rows. We increase the limit to 100000 rows by default.}
+\item{limit}{An optional limit on the total number of rows returned, which
+only applies if you do not specify a limit directly in the \code{sql}
+query. By default seatable limits SQL queries to 100 rows. We increase the
+limit to 100000 rows by default. See \code{paginate} for how this interacts
+with the server's per-call row cap.}
 }
 \value{
 A \code{data.frame} containing all rows from the table. Has an

--- a/tests/testthat/test-flytable.R
+++ b/tests/testthat/test-flytable.R
@@ -101,6 +101,51 @@ test_that("query works", {
 })
 
 
+test_that("flytable_query paginates against a real server", {
+  ac=try(flytable_login())
+  skip_if(inherits(ac, 'try-error'),
+          "skipping flytable pagination tests as unable to login!")
+
+  # `full` fetches testfruit in the normal (single-call) way; `paged` forces
+  # the LIMIT/OFFSET paging path in small windows. Same server, same table, so
+  # the stitched-together paged result must reproduce the full one. (The
+  # Cambridge server's own row cap is far larger than testfruit, so chunksize
+  # is the only way to exercise real multi-page stitching without a huge
+  # table.)
+  full <- try(flytable_query("select * from testfruit"))
+  skip_if(inherits(full, 'try-error') || is.null(full) || nrow(full) < 2,
+          "skipping: testfruit not available")
+
+  paged <- flytable_query("select * from testfruit", chunksize = 20)
+  expect_equal(nrow(paged), nrow(full))
+  expect_setequal(paged[["_id"]], full[["_id"]])
+  # content check: representative columns match row-for-row in _id order.
+  # Compared as character to sidestep column-type inference legitimately
+  # differing between a single fetch and a stitched multi-page one (an all-NA
+  # column in one 20-row page comes back logical, character in the full set).
+  cols <- intersect(c("fruit_name", "person", "nid"), colnames(full))
+  as_key <- function(df) {
+    df <- df[order(df[["_id"]]), cols, drop = FALSE]
+    data.frame(lapply(df, as.character), stringsAsFactors = FALSE)
+  }
+  expect_equal(as_key(paged), as_key(full))
+
+  # flytable_full_fetch drives its own count-based paging loop; force it to
+  # take multiple pages over the same small table.
+  ff <- fafbseg:::flytable_full_fetch("testfruit", chunksize = 20)
+  expect_equal(nrow(ff), nrow(full))
+  expect_setequal(ff[["_id"]], full[["_id"]])
+  expect_false(is.null(attr(ff, "mtime")))
+
+  # Exercise the production auto-detect path (no chunksize) against a table
+  # larger than guaranteed_cap: a first full page followed by a probe that
+  # confirms there is nothing beyond it. `info` has tens of thousands of rows,
+  # so this would come back truncated at 10k were the cap logic broken.
+  info_ids <- try(flytable_query("select _id from info"))
+  if (!inherits(info_ids, 'try-error') && !is.null(info_ids))
+    expect_gt(nrow(info_ids), 10000)
+})
+
 
 test_that("read only shared tables", {
   # check we can handle situation where user is not a full member of workspace


### PR DESCRIPTION
## Problem

Seatable's SQL query endpoint silently caps a single call at a server-specific maximum (documented default **10,000 rows** for SELECT queries, [docs](https://api.seatable.com/reference/limits); self-hosted servers may configure more) with **no error and no truncation signal**. `flytable_full_fetch()` — used by `flytable_cached_table()` and therefore `cam_meta()` — downloaded whole tables with a single `select *` call, so a cold fetch of any table larger than the server's cap silently returned an incomplete result and corrupted the disk cache.

Hit in practice on the `cloud.seatable.io`-hosted `CRANTb_meta` table (12,652 rows) via `crantr::crant_meta()`, which was silently returning only 10,000 rows. Not seen on the Cambridge-hosted server, which raises the caps to 100,000.

The `list-rows` endpoint has its own, lower per-call cap (documented default 1,000), and `flytable_list_rows()` had a related pagination bug.

## Fix

Three targeted changes, all addressing the same root cause (per-call row caps that are **server-specific and not discoverable via any API**), so all self-adapt to whatever cap a server enforces:

1. **`flytable_query()`** gains a `paginate` argument (default `TRUE`) that pages transparently via `LIMIT`/`OFFSET`. Small results and queries that pin their own `limit`/`offset` still cost a single request; it self-establishes the server's cap from the first page. `paginate = FALSE` restores the old single-call behaviour.
2. **`flytable_list_rows()`** loop no longer treats a short page as end-of-table (its pages are always short relative to the over-sized request); it now stops only on a genuinely empty page.
3. **`flytable_full_fetch()`** pages against the table's known row count (fetched with mtime in one `flytable_sync_metadata()` call), so it stops precisely without an extra empty request.

## Testing

- `test-flytable.R` and `test-flytable-cam.R` pass online.
- Verified against the live `CRANTb_meta` (12,652 rows): `flytable_query`, `flytable_full_fetch`, `flytable_list_rows`, `cam_meta`, and a delta-sync round-trip all return the full 12,652 with no warnings; paginated output is byte-identical to a single `flytable_query`.
- Downstream `crantr` test suite passes; `crant_meta()` now returns 12,652 rows.
