### PR TITLE
Fix CAVE id loss and misreported row limits with caveclient 8 / pandas 2.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: fafbseg
 Title: Support Functions for Analysis of FAFB EM Segmentation
-Version: 0.15.12
+Version: 0.15.12.9000
 Authors@R: 
     c(person(given = "Gregory",
              family = "Jefferis",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# fafbseg 0.15.12.9000
+
+Bug fixes:
+
+* CAVE queries no longer lose their 64-bit ids with caveclient 8.x / pandas
+  2.2.x. `pandas_series_character_values()` converted unconditionally with
+  `py_to_r()`, which errors on a series carrying reticulate's `convert` flag
+  because `$tolist()` has already returned an R vector. The error was swallowed,
+  the `bit64::integer64` rescue in `pandas2df_inmem()` silently skipped, and
+  nullable `Int64` id columns arrived as R `integer` with every value overflowed
+  to `NA` (#246).
+* `flywire_partner_summary(method = "cave")` no longer reports unrelated
+  warnings as `"Synapse query exceeded row limit!"` and discards the result.
+  Only a genuine row-limit warning does that now; anything else is passed on and
+  the query kept (#246).
+
 # fafbseg 0.15.12
 
 New features and enhancements:

--- a/R/cave.R
+++ b/R/cave.R
@@ -487,14 +487,27 @@ flywire_partners_cave <- function(rootid, partners=c("outputs", "inputs"),
   }
   dict=list(as.list(as.character(rootid)))
   names(dict)=ifelse(partners=="outputs", "pre_pt_root_id", "post_pt_root_id")
-  res=tryCatch(flywire_cave_query(datastack_name = datastack_name,
-                         table = synapse_table,
-                         filter_in_dict=cavedict_rtopy(dict),
-                         ...),
-               warning=function(e) {
-                 warning("Synapse query exceeded row limit!")
-                 NULL
-               })
+  # Collect warnings rather than aborting on the first one, so that only a
+  # genuine row limit discards the result. Warnings from elsewhere in the stack
+  # (a pandas or google-api deprecation surfaced through reticulate, say) used
+  # to be reported as a row limit and turn a successful query into NULL.
+  warnings_seen=character()
+  res=withCallingHandlers(
+    flywire_cave_query(datastack_name = datastack_name,
+                       table = synapse_table,
+                       filter_in_dict=cavedict_rtopy(dict),
+                       ...),
+    warning=function(w) {
+      warnings_seen <<- c(warnings_seen, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    })
+  rowlimited=grepl("Limited query to|row limit", warnings_seen)
+  # Pass on anything unrelated, so it is neither hidden nor mistaken for a limit.
+  for(w in warnings_seen[!rowlimited]) warning(w, call. = FALSE)
+  if(any(rowlimited)) {
+    warning("Synapse query exceeded row limit!")
+    return(NULL)
+  }
   if(is.null(res)) return(res)
   # FIXME - integrate into CAVE query
   if(cleft.threshold>0)

--- a/R/cave.R
+++ b/R/cave.R
@@ -471,6 +471,28 @@ cavedict_rtopy <- function(dict, wrap_table=NULL) {
   pydict
 }
 
+# Evaluate a CAVE query, returning NULL only when the server actually truncated
+# the result. Warnings raised anywhere else in the stack (a pandas or
+# google-api deprecation surfaced through reticulate, say) are passed on and the
+# result kept. Previously any warning at all was reported as a row limit, so a
+# successful query became NULL under a message pointing at the wrong cause.
+#
+# `expr` is a promise, evaluated here so its warnings are caught.
+drop_if_row_limited <- function(expr) {
+  seen=character()
+  res=withCallingHandlers(expr, warning=function(w) {
+    seen <<- c(seen, conditionMessage(w))
+    invokeRestart("muffleWarning")
+  })
+  limited=grepl("Limited query to|row limit", seen)
+  for(w in seen[!limited]) warning(w, call. = FALSE)
+  if(any(limited)) {
+    warning("Synapse query exceeded row limit!")
+    return(NULL)
+  }
+  res
+}
+
 flywire_partners_cave <- function(rootid, partners=c("outputs", "inputs"),
                                   cleft.threshold=0,
                                   datastack_name = getOption("fafbseg.cave.datastack_name", "flywire_fafb_production"),
@@ -487,27 +509,11 @@ flywire_partners_cave <- function(rootid, partners=c("outputs", "inputs"),
   }
   dict=list(as.list(as.character(rootid)))
   names(dict)=ifelse(partners=="outputs", "pre_pt_root_id", "post_pt_root_id")
-  # Collect warnings rather than aborting on the first one, so that only a
-  # genuine row limit discards the result. Warnings from elsewhere in the stack
-  # (a pandas or google-api deprecation surfaced through reticulate, say) used
-  # to be reported as a row limit and turn a successful query into NULL.
-  warnings_seen=character()
-  res=withCallingHandlers(
+  res=drop_if_row_limited(
     flywire_cave_query(datastack_name = datastack_name,
                        table = synapse_table,
                        filter_in_dict=cavedict_rtopy(dict),
-                       ...),
-    warning=function(w) {
-      warnings_seen <<- c(warnings_seen, conditionMessage(w))
-      invokeRestart("muffleWarning")
-    })
-  rowlimited=grepl("Limited query to|row limit", warnings_seen)
-  # Pass on anything unrelated, so it is neither hidden nor mistaken for a limit.
-  for(w in warnings_seen[!rowlimited]) warning(w, call. = FALSE)
-  if(any(rowlimited)) {
-    warning("Synapse query exceeded row limit!")
-    return(NULL)
-  }
+                       ...))
   if(is.null(res)) return(res)
   # FIXME - integrate into CAVE query
   if(cleft.threshold>0)

--- a/R/utils.R
+++ b/R/utils.R
@@ -940,15 +940,29 @@ classify_object_values <- function(vals) {
   vals
 }
 
+# Whether a series carries reticulate's convert flag decides whether calls on it
+# come back as python objects or as already-converted R vectors. Converting
+# unconditionally errors on the latter with "Object to convert is not a Python
+# object", which used to be swallowed by the try() below, silently disabling the
+# int64 rescue in pandas2df_inmem() and leaving 64-bit ids overflowed to NA.
+py_to_r_if_needed <- function(x) {
+  if(inherits(x, "python.builtin.object")) reticulate::py_to_r(x) else x
+}
+
 pandas_series_character_values <- function(series) {
   bt <- reticulate::import_builtins(convert = FALSE)
-  vals <- try(reticulate::py_to_r(reticulate::py_call(series$map, bt$str)$tolist()),
-              silent = TRUE)
+  vals <- try(py_to_r_if_needed(
+    reticulate::py_call(series$map, bt$str)$tolist()), silent = TRUE)
   if(inherits(vals, "try-error"))
     return(NULL)
-  missing <- reticulate::py_to_r(reticulate::py_call(
-    reticulate::py_call(series$isna)$to_numpy))
-  vals[missing] <- NA_character_
+  vals <- as.character(unlist(vals, use.names = FALSE))
+  missing <- try(py_to_r_if_needed(reticulate::py_call(
+    reticulate::py_call(series$isna)$to_numpy)), silent = TRUE)
+  if(inherits(missing, "try-error"))
+    return(NULL)
+  missing <- as.logical(missing)
+  if(length(missing) == length(vals))
+    vals[missing] <- NA_character_
   vals
 }
 

--- a/tests/testthat/test-cave.R
+++ b/tests/testthat/test-cave.R
@@ -79,3 +79,34 @@ test_that("flywire_timestamp", {
   # now -> current time, convert=F python object
   expect_is(flywire_timestamp(timestamp = 'now', convert = F), "datetime.date")
 })
+
+test_that("drop_if_row_limited only discards genuine row limits (#246)", {
+  # No warning: result passes through.
+  expect_equal(drop_if_row_limited(data.frame(a = 1:2)), data.frame(a = 1:2))
+
+  # A row limit discards the result and says so.
+  limited <- function() {
+    warning("201 - \"Limited query to 5 rows")
+    data.frame(a = 1)
+  }
+  expect_warning(res <- drop_if_row_limited(limited()),
+                 "exceeded row limit")
+  expect_null(res)
+
+  # An unrelated warning keeps the result and is passed on rather than being
+  # relabelled as a row limit. This is the pandas deprecation case.
+  noisy <- function() {
+    warning("FutureWarning: Index.format is deprecated")
+    data.frame(a = 1:3)
+  }
+  expect_warning(res <- drop_if_row_limited(noisy()), "Index.format")
+  expect_equal(nrow(res), 3L)
+
+  # Both kinds together: still treated as a row limit.
+  both <- function() {
+    warning("FutureWarning: Index.format is deprecated")
+    warning("row limit reached")
+    data.frame(a = 1)
+  }
+  expect_null(suppressWarnings(drop_if_row_limited(both())))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -82,6 +82,30 @@ test_that("pandas2df in-memory conversion reads pandas Series explicitly", {
   expect_identical(out$label, c("a", "b"))
 })
 
+test_that("pandas2df patches nullable ids on a convert=TRUE frame (#246)", {
+  skip_if_not_installed('reticulate')
+  skip_if_not(reticulate::py_available())
+  skip_if_not(reticulate::py_module_available("pandas"))
+
+  # caveclient hands back frames carrying reticulate's convert flag, on which
+  # $tolist() returns an R vector rather than a python object. That used to
+  # abort the int64 rescue, leaving 64-bit ids overflowed to NA.
+  reticulate::py_run_string("
+import pandas as pd
+pdf_convert_ids = pd.DataFrame({'pt_root_id': [720575940631797753]})
+pdf_convert_ids['pt_root_id'] = pdf_convert_ids['pt_root_id'].astype('Int64')
+")
+  df <- reticulate::py_eval("pdf_convert_ids", convert = TRUE)
+  skip_if_not(inherits(df, "python.builtin.object"))
+
+  series <- reticulate::py_get_item(df, "pt_root_id")
+  expect_equal(pandas_series_character_values(series), "720575940631797753")
+
+  out <- pandas2df(df)
+  expect_true(bit64::is.integer64(out$pt_root_id))
+  expect_equal(as.character(out$pt_root_id), "720575940631797753")
+})
+
 test_that("pandas2df in-memory conversion patches nullable ids and datetimes", {
   skip_if_not_installed('reticulate')
   skip_if_not(reticulate::py_available())

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -231,3 +231,16 @@ test_that("classify_object_values falls through to character on mixed content", 
     c("foo", "bar")
   )
 })
+
+test_that("py_to_r_if_needed leaves R objects alone (#246)", {
+  expect_identical(py_to_r_if_needed(c("a", "b")), c("a", "b"))
+  expect_identical(py_to_r_if_needed(list(1, 2)), list(1, 2))
+  expect_null(py_to_r_if_needed(NULL))
+
+  skip_if_not_installed('reticulate')
+  skip_if_not(reticulate::py_available())
+  py_list <- reticulate::r_to_py(list("a", "b"), convert = FALSE)
+  expect_true(inherits(py_list, "python.builtin.object"))
+  # reticulate simplifies a list of strings to a character vector on the way back
+  expect_identical(py_to_r_if_needed(py_list), c("a", "b"))
+})


### PR DESCRIPTION
Fixes #246. Two faults with caveclient 8.x and pandas 2.2.x.

## Fault 1: 64-bit ids silently become NA

* `pandas_series_character_values()` called `py_to_r()` unconditionally.
* On a series carrying reticulate's `convert` flag, which is what caveclient
  returns, `$tolist()` has already produced an R vector, so `py_to_r()` errors
  with `Object to convert is not a Python object`.
* The `try()` swallowed it, the `bit64::integer64` rescue in
  `pandas2df_inmem()` was silently skipped, and nullable `Int64` id columns
  arrived as R `integer` with every value overflowed to `NA`.
* Fix: convert only when the value is still a python object. Same guard on the
  `isna()`/`to_numpy()` line.

The silent `NA` is the damaging part. After thresholding, the result collapses
to a single row holding the total synapse count, which reads as a plausible
answer rather than a failure.

## Fault 2: unrelated warnings reported as a row limit

* `flywire_partners_cave()` caught every warning, emitted
  `"Synapse query exceeded row limit!"` and returned `NULL`.
* pandas 2.2 emits an unrelated `Index.format is deprecated` FutureWarning, so
  successful queries became `NULL` under a message pointing at the wrong cause.
* Fix: collect warnings, discard the result only for a genuine row limit, pass
  anything else on and keep the query.

## Before and after

On `flywire_fafb_production`:

```r
id <- flywire_latestid("720575940621039145")
flywire_partner_summary(id, partners = "outputs", threshold = 10, method = "cave")
```

* before: `NULL`, with `Synapse query exceeded row limit!`
* after: 52 rows, ids as `integer64` rather than `NA`

Raw query ids go from `class "integer"`, all `NA`, to `integer64` with correct
values.

## Tests

* Regression test added in `test-utils.R`, built with `convert = TRUE`. The
  existing `pandas2df` tests all use `convert = FALSE`, which is why this went
  unnoticed. It fails on master and passes here.
* `test-utils`: 51 pass.
* `test-cave`: goes from 2 failures to 1. The remaining `expect_silent` failure
  at `test-cave.R:62` is pre-existing on master, caused by the same pandas
  deprecation warning, and is left alone.
* Downstream check: this also fixes bancr's `test-banc-coconatfly.R`, which
  fails on bancr master and passes with this branch installed.

Version bumped to 0.15.12.9000.
