### PR TITLE
Fix 64-bit id loss in nullable int columns containing NA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: fafbseg
 Title: Support Functions for Analysis of FAFB EM Segmentation
-Version: 0.15.13
+Version: 0.15.13.9000
 Authors@R: 
     c(person(given = "Gregory",
              family = "Jefferis",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# fafbseg (development version)
+
+Bug fixes:
+
+* `pandas2df()` no longer loses 64-bit ids from a nullable `Int64`/`UInt64`
+  column that contains a missing value. `pandas_series_character_values()` read
+  cells with `Series.map(str)`, which upcasts such a column to `float64` before
+  stringifying, so ids came back in scientific notation and the `integer64`
+  rescue collapsed the whole column to `NA`. It now uses `Series.astype("str")`,
+  which stringifies the integer cells exactly. Pre-existing and independent of
+  the caveclient `convert`-flag fix in 0.15.13.
+
 # fafbseg 0.15.13
 
 Bug fixes:

--- a/R/utils.R
+++ b/R/utils.R
@@ -950,9 +950,14 @@ py_to_r_if_needed <- function(x) {
 }
 
 pandas_series_character_values <- function(series) {
-  bt <- reticulate::import_builtins(convert = FALSE)
+  # astype("str"), not map(str): mapping python str() over a nullable Int64 /
+  # UInt64 Series that holds a missing value first upcasts it to float64, so
+  # 64-bit ids come back in scientific notation and lose precision -- and the
+  # int64 rescue in pandas2df_inmem() then collapses the whole column to NA.
+  # astype("str") stringifies the integer cells exactly and renders missing
+  # cells as "<NA>", which the isna() mask below turns into NA.
   vals <- try(py_to_r_if_needed(
-    reticulate::py_call(series$map, bt$str)$tolist()), silent = TRUE)
+    reticulate::py_call(series$astype, "str")$tolist()), silent = TRUE)
   if(inherits(vals, "try-error"))
     return(NULL)
   vals <- as.character(unlist(vals, use.names = FALSE))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -106,6 +106,80 @@ pdf_convert_ids['pt_root_id'] = pdf_convert_ids['pt_root_id'].astype('Int64')
   expect_equal(as.character(out$pt_root_id), "720575940631797753")
 })
 
+test_that("pandas2df preserves 64-bit ids in a nullable Int64 column with NA", {
+  skip_if_not_installed('reticulate')
+  skip_if_not(reticulate::py_available())
+  skip_if_not(reticulate::py_module_available("pandas"))
+
+  # A nullable Int64/UInt64 column holding a missing value used to lose all
+  # precision: pandas upcasts it to float64 before stringifying, so 64-bit ids
+  # came back in scientific notation and the int64 rescue collapsed the whole
+  # column to NA. Convert-agnostic, so this runs under convert=FALSE.
+  reticulate::py_run_string("
+import pandas as pd
+pdf_na_ids = pd.DataFrame(
+    {'pt_root_id': [720575940631797753, pd.NA, 80999991094644060]})
+pdf_na_ids['pt_root_id'] = pdf_na_ids['pt_root_id'].astype('Int64')
+")
+  df <- reticulate::py_eval("pdf_na_ids", convert = FALSE)
+
+  series <- reticulate::py_get_item(df, "pt_root_id")
+  expect_equal(pandas_series_character_values(series),
+               c("720575940631797753", NA, "80999991094644060"))
+
+  out <- pandas2df(df)
+  expect_true(bit64::is.integer64(out$pt_root_id))
+  expect_equal(as.character(out$pt_root_id),
+               c("720575940631797753", NA, "80999991094644060"))
+})
+
+test_that("pandas2df preserves ids with an NA on a convert=TRUE frame", {
+  skip_if_not_installed('reticulate')
+  skip_if_not(reticulate::py_available())
+  skip_if_not(reticulate::py_module_available("pandas"))
+
+  # Same missing-value case at the production input shape caveclient returns: a
+  # frame carrying reticulate's convert flag. Skips where py_eval() fully
+  # converts the frame to R rather than keeping it a python object.
+  reticulate::py_run_string("
+import pandas as pd
+pdf_na_ids_ct = pd.DataFrame(
+    {'pt_root_id': [720575940631797753, pd.NA, 80999991094644060]})
+pdf_na_ids_ct['pt_root_id'] = pdf_na_ids_ct['pt_root_id'].astype('Int64')
+")
+  df <- reticulate::py_eval("pdf_na_ids_ct", convert = TRUE)
+  skip_if_not(inherits(df, "python.builtin.object"))
+
+  out <- pandas2df(df)
+  expect_true(bit64::is.integer64(out$pt_root_id))
+  expect_equal(as.character(out$pt_root_id),
+               c("720575940631797753", NA, "80999991094644060"))
+})
+
+test_that("pandas2df flattens scalars but keeps list cells on a convert=TRUE frame", {
+  skip_if_not_installed('reticulate')
+  skip_if_not(reticulate::py_available())
+  skip_if_not(reticulate::py_module_available("pandas"))
+
+  # Object-dtype handling is only tested under convert=FALSE. A convert=TRUE
+  # frame must still flatten a uniform-scalar object column (the L2-cache int
+  # shape, values > 2^31) to an atomic vector, while leaving genuine
+  # multi-select list cells as a list rather than capturing their "['AB']" repr.
+  reticulate::py_run_string("
+import pandas as pd
+pdf_convert_obj = pd.DataFrame({
+    'size_nm3': pd.Series([90040320, 3999835136], dtype='object'),
+    'tags': pd.Series([['AB'], ['CD']], dtype='object'),
+})
+")
+  df <- reticulate::py_eval("pdf_convert_obj", convert = TRUE)
+  skip_if_not(inherits(df, "python.builtin.object"))
+
+  out <- pandas2df(df)
+  expect_equal(out$size_nm3, c(90040320, 3999835136))
+  expect_identical(out$tags, list("AB", "CD"))
+})
+
 test_that("pandas2df in-memory conversion patches nullable ids and datetimes", {
   skip_if_not_installed('reticulate')
   skip_if_not(reticulate::py_available())


### PR DESCRIPTION
## Summary

Fixes a **pre-existing** 64-bit id corruption in `pandas2df()`, separate from and predating the caveclient `convert`-flag fix in #247 / 0.15.13. Found while adding the boundary-shape regression tests suggested after #247.

## The bug

`pandas_series_character_values()` read cell strings with `Series.map(str)`. On a nullable `Int64`/`UInt64` column that contains a missing value, pandas **upcasts the column to `float64` before stringifying**, so ids come back in scientific notation:

```python
s.map(str)      # ['7.205759406317978e+17', 'nan']   <- precision lost
s.astype('str') # ['720575940631797753', '<NA>']     <- exact
```

The overflowed values then fail the `integer64` rescue in `pandas2df_inmem()` and the **whole column collapses to `NA`**. It hits any nullable int column with at least one missing value, and is **convert-agnostic** (reproduces under `convert=FALSE`). It went unnoticed because no test exercised a nullable int column holding an actual `NA` — existing fixtures use fully-populated rows.

## The fix

One line: `Series.map(str)` → `Series.astype("str")`. Verified across single int64, `Int64`+`NA`, `UInt64` (incl. `uint64`-max), and object-dtype scalar columns, under both `convert` modes.

## Tests

- `convert=FALSE` nullable `Int64` with `NA` — runs offline, guards the fix (fails on master, passes here).
- `convert=TRUE` variant at caveclient's actual input shape — skips where `py_eval()` fully converts the frame.
- `convert=TRUE` object column — uniform scalars flatten, multi-select list cells preserved.

`test-utils`: FAIL=0, PASS=56, SKIP=3.

Bumps to development version `0.15.13.9000`.
