### PR TITLE
Fix df2flytable stringifying int64 column index instead of values

### DIFF
--- a/R/flytable.R
+++ b/R/flytable.R
@@ -935,7 +935,7 @@ df2flytable <- function(df, append=TRUE, multi_select_cols=character(0)) {
 
   int64cols=sapply(df, bit64::is.integer64)
   for(i in which(int64cols)) {
-    df[[i]]=as.character(i)
+    df[[i]]=as.character(df[[i]])
   }
 
   multi_select_cols=intersect(multi_select_cols, colnames(df))

--- a/tests/testthat/test-flytable.R
+++ b/tests/testthat/test-flytable.R
@@ -260,6 +260,18 @@ test_that("multi-select comma-string shorthand splits correctly", {
               list(c("AB,CD", "EF")))
 })
 
+test_that("df2flytable stringifies integer64 columns by value", {
+  # a bit64::integer64 column must serialise to the string form of its
+  # *values*, not its column index (regression: as.character(i) vs df[[i]])
+  df <- data.frame(row_id = c("r1", "r2"), stringsAsFactors = FALSE)
+  df$rootid <- bit64::as.integer64(
+    c("720575940621039145", "720575940626877799"))
+  out <- fafbseg:::df2flytable(df, append = FALSE)
+  expect_type(out$rootid, "character")
+  expect_equal(out$rootid,
+               c("720575940621039145", "720575940626877799"))
+})
+
 
 test_that("delta sync row update handles POSIXct columns", {
   # R's [<-.data.frame with whole-row assignment fails with mixed POSIXct/other


### PR DESCRIPTION
## Summary

`df2flytable()`'s int64-to-character loop stringified the **column index** instead of the **column values**:

```r
int64cols = sapply(df, bit64::is.integer64)
for (i in which(int64cols)) {
  df[[i]] = as.character(i)   # i is a column index, e.g. 2L -> "2"
}
```

`which(int64cols)` returns column positions, so `as.character(i)` yields a length-1 string like `"2"` that is recycled into every row of that column. A `bit64::integer64` column is therefore overwritten with its own position and that corrupted value is sent to SeaTable **on write**.

Fix: stringify the values, `as.character(df[[i]])`.

## Scope / why it's latent

- **Write path only** — `df2flytable()` is called solely by `flytable_update_rows()` and `flytable_append_rows()`; reads use `flytable2df()` and are unaffected.
- It rarely fires because ids almost always reach the write path as **character** columns already (root_ids/supervoxels are text columns; `_id`/`row_id` are strings), so `is.integer64` is `FALSE` for every column and the loop body never runs. It only bites a caller who builds a write frame with a live `integer64` column.

## Testing

Added an offline regression test (`df2flytable stringifies integer64 columns by value`) asserting an `integer64` column round-trips to the string form of its values, not `"N"`. Passes; the pre-fix form produced `"2","2"`.

## Note

Spotted while porting these row-write helpers into `seatabler`, whose port already carries the corrected form.
